### PR TITLE
feat: client onboarding wizard, in-app notifications & assign consultant

### DIFF
--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $user = Auth::user();
+
+        $notifications = $user->notifications()
+            ->latest()
+            ->limit(30)
+            ->get()
+            ->map(fn ($n) => [
+                'id'         => $n->id,
+                'type'       => $n->data['type'] ?? null,
+                'data'       => $n->data,
+                'read'       => ! is_null($n->read_at),
+                'created_at' => $n->created_at,
+            ]);
+
+        return response()->json([
+            'notifications' => $notifications,
+            'unread_count'  => $user->unreadNotifications()->count(),
+        ]);
+    }
+
+    public function markRead(string $id): JsonResponse
+    {
+        Auth::user()->notifications()->findOrFail($id)->markAsRead();
+
+        return response()->json(['message' => 'Marked as read.']);
+    }
+
+    public function markAllRead(): JsonResponse
+    {
+        Auth::user()->unreadNotifications->markAsRead();
+
+        return response()->json(['message' => 'All notifications marked as read.']);
+    }
+}

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\UserRequest;
 use App\Http\Resources\UserResource;
 use App\Models\User;
+use App\Notifications\NewClientOnboarded;
 use App\Services\UserService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -129,6 +130,69 @@ class UserController extends Controller
             'message' => 'Avatar updated successfully',
             'path' => $path,
             'url' => asset('storage/'.$path),
+        ]);
+    }
+
+    public function consultants(): AnonymousResourceCollection
+    {
+        $consultants = User::role('consultant')->with(['profile', 'roles'])->get();
+
+        return UserResource::collection($consultants);
+    }
+
+    public function assignConsultant(Request $request, User $user): JsonResponse
+    {
+        if (! Auth::user()->hasRole('admin')) {
+            return response()->json(['message' => 'Only admins can assign consultants.'], 403);
+        }
+
+        $request->validate([
+            'consultant_id' => 'nullable|exists:users,id',
+        ]);
+
+        if ($request->consultant_id) {
+            $consultant = User::findOrFail($request->consultant_id);
+            if (! $consultant->hasRole('consultant')) {
+                return response()->json(['message' => 'Selected user is not a consultant.'], 422);
+            }
+        }
+
+        $user->update(['consultant_id' => $request->consultant_id]);
+        $user->load(['profile', 'roles', 'consultant']);
+
+        return response()->json([
+            'message' => 'Consultant assigned successfully.',
+            'user'    => new UserResource($user),
+        ]);
+    }
+
+    public function completeOnboarding(Request $request): JsonResponse
+    {
+        $user = Auth::user();
+
+        $data = $request->validate([
+            'profession'         => 'required|string|max:255',
+            'level'              => 'required|in:junior,mid,senior,manager',
+            'stack'              => 'required|array|min:1',
+            'stack.*'            => 'string|max:50',
+            'product_interest'   => 'required|in:self-serve,bootcamp,mentorship',
+            'availability_hours' => 'required|integer|min:1|max:80',
+            'timeline'           => 'required|in:1-3m,3-6m,6-12m,flexible',
+            'goal'               => 'nullable|string|max:500',
+        ]);
+
+        $user->profile()->updateOrCreate(
+            ['user_id' => $user->id],
+            $data
+        );
+
+        $user->load('profile', 'roles');
+
+        User::role('admin')->each(fn (User $admin) => $admin->notify(new NewClientOnboarded($user)));
+
+        return response()->json([
+            'message' => 'Onboarding complete',
+            'user'    => new UserResource($user),
         ]);
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -10,16 +10,30 @@ class UserResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'id' => $this->id,
-            'fullname' => $this->fullname,
-            'email' => $this->email,
+            'id'                => $this->id,
+            'fullname'          => $this->fullname,
+            'email'             => $this->email,
             'email_verified_at' => $this->email_verified_at,
-            'role' => $this->roles->first()?->name,
+            'role'              => $this->roles->first()?->name,
+            'consultant_id'     => $this->consultant_id,
+            'consultant'        => $this->when($this->relationLoaded('consultant'), function () {
+                return $this->consultant ? [
+                    'id'       => $this->consultant->id,
+                    'fullname' => $this->consultant->fullname,
+                    'email'    => $this->consultant->email,
+                ] : null;
+            }),
             'profile' => $this->when($this->relationLoaded('profile'), function () {
                 return $this->profile ? [
-                    'birth_date' => $this->profile->birth_date,
-                    'profession' => $this->profile->profession,
-                    'profile_image' => $this->profile->profile_image,
+                    'birth_date'         => $this->profile->birth_date,
+                    'profession'         => $this->profile->profession,
+                    'goal'               => $this->profile->goal,
+                    'level'              => $this->profile->level,
+                    'stack'              => $this->profile->stack,
+                    'product_interest'   => $this->profile->product_interest,
+                    'availability_hours' => $this->profile->availability_hours,
+                    'timeline'           => $this->profile->timeline,
+                    'profile_image'      => $this->profile->profile_image,
                     'profile_image_url' => $this->profile->profile_image
                         ? asset('storage/'.$this->profile->profile_image)
                         : null,

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -13,12 +13,22 @@ class Profile extends Model
         'user_id',
         'birth_date',
         'profession',
+        'goal',
+        'level',
+        'stack',
+        'product_interest',
+        'availability_hours',
+        'timeline',
         'profile_image',
         'website',
         'github',
         'linkedin',
         'instagram',
         'facebook',
+    ];
+
+    protected $casts = [
+        'stack' => 'array',
     ];
 
     public function user()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ class User extends Authenticatable
         'password_confirmation',
         'google_id',
         'email_verified_at',
+        'consultant_id',
     ];
 
     /**
@@ -54,6 +55,16 @@ class User extends Authenticatable
     public function profile(): HasOne
     {
         return $this->hasOne(Profile::class);
+    }
+
+    public function consultant(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(User::class, 'consultant_id');
+    }
+
+    public function clients(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(User::class, 'consultant_id');
     }
 
     /**

--- a/app/Notifications/NewClientOnboarded.php
+++ b/app/Notifications/NewClientOnboarded.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Notifications\Notification;
+
+class NewClientOnboarded extends Notification
+{
+    public function __construct(private readonly User $client) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        $profile = $this->client->profile;
+
+        return [
+            'type'               => 'new_client_onboarded',
+            'client_id'          => $this->client->id,
+            'fullname'           => $this->client->fullname,
+            'profession'         => $profile?->profession,
+            'level'              => $profile?->level,
+            'stack'              => $profile?->stack,
+            'product_interest'   => $profile?->product_interest,
+            'availability_hours' => $profile?->availability_hours,
+            'timeline'           => $profile?->timeline,
+            'goal'               => $profile?->goal,
+        ];
+    }
+}

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -32,7 +32,7 @@ class UserService
 
     public function find(int $id): User
     {
-        return User::with(['profile', 'roles'])->findOrFail($id);
+        return User::with(['profile', 'roles', 'consultant'])->findOrFail($id);
     }
 
     public function create(array $data): User

--- a/database/migrations/2026_04_19_100000_add_goal_to_profiles_table.php
+++ b/database/migrations/2026_04_19_100000_add_goal_to_profiles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->string('goal')->nullable()->after('profession');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->dropColumn('goal');
+        });
+    }
+};

--- a/database/migrations/2026_04_19_135844_add_email_verified_at_to_users_table.php
+++ b/database/migrations/2026_04_19_135844_add_email_verified_at_to_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('email_verified_at')->nullable()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('email_verified_at');
+        });
+    }
+};

--- a/database/migrations/2026_04_19_140329_create_notifications_table.php
+++ b/database/migrations/2026_04_19_140329_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/2026_04_19_144744_add_onboarding_fields_to_profiles_table.php
+++ b/database/migrations/2026_04_19_144744_add_onboarding_fields_to_profiles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->string('level')->nullable()->after('goal');
+            $table->json('stack')->nullable()->after('level');
+            $table->string('product_interest')->nullable()->after('stack');
+            $table->unsignedTinyInteger('availability_hours')->nullable()->after('product_interest');
+            $table->string('timeline')->nullable()->after('availability_hours');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->dropColumn(['level', 'stack', 'product_interest', 'availability_hours', 'timeline']);
+        });
+    }
+};

--- a/frontend/composables/useNotifications.ts
+++ b/frontend/composables/useNotifications.ts
@@ -1,0 +1,50 @@
+interface AppNotification {
+  id: string
+  type: string | null
+  data: Record<string, any>
+  read: boolean
+  created_at: string
+}
+
+export const useNotifications = () => {
+  const { get, patch } = useApi()
+
+  const notifications = ref<AppNotification[]>([])
+  const unreadCount   = ref(0)
+  const loading       = ref(false)
+
+  async function fetchNotifications() {
+    loading.value = true
+    try {
+      const res = await get<{ notifications: AppNotification[]; unread_count: number }>('/notifications')
+      notifications.value = res.notifications
+      unreadCount.value   = res.unread_count
+    } catch {
+      // silent — bell just shows stale data
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function markRead(id: string) {
+    await patch(`/notifications/${id}/read`, {})
+    const n = notifications.value.find(n => n.id === id)
+    if (n) { n.read = true }
+    if (unreadCount.value > 0) unreadCount.value--
+  }
+
+  async function markAllRead() {
+    await patch('/notifications/read-all', {})
+    notifications.value.forEach(n => { n.read = true })
+    unreadCount.value = 0
+  }
+
+  return {
+    notifications: readonly(notifications),
+    unreadCount:   readonly(unreadCount),
+    loading:       readonly(loading),
+    fetchNotifications,
+    markRead,
+    markAllRead,
+  }
+}

--- a/frontend/layouts/admin.vue
+++ b/frontend/layouts/admin.vue
@@ -123,12 +123,57 @@
 
           <UButton :icon="isDark ? 'i-heroicons-sun' : 'i-heroicons-moon'"
             color="gray" variant="ghost" size="sm" @click="toggleColorMode" />
-          <UPopover>
-            <UButton icon="i-heroicons-bell" color="gray" variant="ghost" size="sm" />
-            <template #panel>
-              <div class="w-72 p-4">
-                <p class="mb-1 text-sm font-semibold text-gray-900 dark:text-white">Notifications</p>
-                <p class="text-sm text-gray-400 dark:text-slate-500">Nothing new</p>
+          <UPopover @open="fetchNotifications">
+            <div class="relative">
+              <UButton icon="i-heroicons-bell" color="gray" variant="ghost" size="sm" />
+              <span
+                v-if="unreadCount > 0"
+                class="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center
+                       rounded-full bg-indigo-500 text-[9px] font-bold text-white"
+              >{{ unreadCount > 9 ? '9+' : unreadCount }}</span>
+            </div>
+            <template #panel="{ close }">
+              <div class="w-80">
+                <div class="flex items-center justify-between border-b border-gray-100 px-4 py-3 dark:border-slate-700">
+                  <p class="text-sm font-semibold text-gray-900 dark:text-white">Notifications</p>
+                  <button
+                    v-if="unreadCount > 0"
+                    class="text-xs text-indigo-500 hover:underline"
+                    @click="markAllRead"
+                  >Mark all read</button>
+                </div>
+                <div v-if="loading" class="px-4 py-6 text-center text-sm text-gray-400">Loading…</div>
+                <div v-else-if="notifications.length === 0" class="px-4 py-6 text-center text-sm text-gray-400 dark:text-slate-500">
+                  Nothing new
+                </div>
+                <ul v-else class="max-h-80 overflow-y-auto divide-y divide-gray-50 dark:divide-slate-800">
+                  <li
+                    v-for="n in notifications"
+                    :key="n.id"
+                    class="flex cursor-pointer gap-3 px-4 py-3 transition-colors hover:bg-gray-50 dark:hover:bg-slate-800/60"
+                    :class="n.read ? 'opacity-60' : ''"
+                    @click="handleNotificationClick(n, close)"
+                  >
+                    <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-900/40">
+                      <UIcon name="i-heroicons-user-plus" class="h-4 w-4 text-indigo-500" />
+                    </span>
+                    <div class="min-w-0 flex-1">
+                      <p class="text-[13px] font-medium text-gray-800 dark:text-slate-200 leading-snug">
+                        <span class="font-semibold">{{ n.data.fullname }}</span> completed onboarding
+                      </p>
+                      <p class="mt-0.5 text-[11px] text-gray-400 dark:text-slate-500">
+                        {{ n.data.profession }} · {{ n.data.level }} · {{ n.data.product_interest }}
+                      </p>
+                      <p v-if="n.data.stack?.length" class="mt-0.5 text-[11px] text-gray-400 dark:text-slate-500">
+                        {{ n.data.stack.join(', ') }} · {{ n.data.availability_hours }}h/week · {{ n.data.timeline }}
+                      </p>
+                      <p class="mt-0.5 text-[10px] text-gray-300 dark:text-slate-600">
+                        {{ timeAgo(n.created_at) }}
+                      </p>
+                    </div>
+                    <span v-if="!n.read" class="mt-2 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
+                  </li>
+                </ul>
               </div>
             </template>
           </UPopover>
@@ -173,6 +218,26 @@ const { user, logout } = useAuth()
 const route            = useRoute()
 const colorMode        = useColorMode()
 const sidebarOpen      = ref(false)
+
+const { notifications, unreadCount, loading, fetchNotifications, markRead, markAllRead } = useNotifications()
+
+onMounted(fetchNotifications)
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1)  return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  return `${Math.floor(h / 24)}d ago`
+}
+
+async function handleNotificationClick(n: any, close: () => void) {
+  if (!n.read) await markRead(n.id)
+  close()
+  if (n.data?.client_id) navigateTo(`/users/${n.data.client_id}`)
+}
 
 // Close sidebar on route change
 watch(() => route.path, () => { sidebarOpen.value = false })

--- a/frontend/pages/auth/callback.vue
+++ b/frontend/pages/auth/callback.vue
@@ -31,7 +31,8 @@ onMounted(() => {
   try {
     const user = JSON.parse(decodeURIComponent(raw))
     setAuth(token, user)
-    navigateTo('/dashboard')
+    const dest = user?.profile?.profession ? '/dashboard' : '/onboarding'
+    navigateTo(dest)
   } catch {
     error.value = 'Could not complete sign-in. Please try again.'
   }

--- a/frontend/pages/onboarding.vue
+++ b/frontend/pages/onboarding.vue
@@ -1,0 +1,527 @@
+<template>
+  <div class="onboarding-page">
+    <div class="onboarding-card">
+
+      <!-- Header -->
+      <div class="card-header">
+        <NuxtLink to="/" class="logo-link">
+          <img src="/images/codecv.png" alt="CODECV" class="logo" onerror="this.style.display='none'" />
+        </NuxtLink>
+        <h1>Welcome, {{ user?.fullname?.split(' ')[0] }}!</h1>
+        <p>Help us personalise your experience — takes 60 seconds.</p>
+      </div>
+
+      <!-- Step indicator -->
+      <div class="steps">
+        <div v-for="i in 3" :key="i" class="step-item">
+          <div class="step-circle" :class="stepClass(i)">
+            <UIcon v-if="i < step" name="i-heroicons-check" class="h-3.5 w-3.5" />
+            <span v-else>{{ i }}</span>
+          </div>
+          <div v-if="i < 3" class="step-line" :class="i < step ? 'step-line--done' : ''" />
+        </div>
+      </div>
+
+      <!-- ── STEP 1 — Your profile ──────────────────────────── -->
+      <Transition :name="transitionName" mode="out-in">
+        <div v-if="step === 1" key="1" class="step-body">
+          <h2 class="step-title">Your profile</h2>
+
+          <div class="field">
+            <label>Current role</label>
+            <div class="field__wrap">
+              <UIcon name="i-heroicons-briefcase" class="field__ico" />
+              <select v-model="form.profession" required>
+                <option value="" disabled>Select your role…</option>
+                <optgroup label="Development">
+                  <option>Frontend Developer</option>
+                  <option>Backend Developer</option>
+                  <option>Full-Stack Developer</option>
+                  <option>Mobile Developer</option>
+                  <option>DevOps / Platform Engineer</option>
+                  <option>Data Engineer</option>
+                  <option>Machine Learning Engineer</option>
+                </optgroup>
+                <optgroup label="Other IT">
+                  <option>QA / Test Engineer</option>
+                  <option>Cloud Architect</option>
+                  <option>Security Engineer</option>
+                  <option>IT Manager / Tech Lead</option>
+                  <option>Product Manager</option>
+                  <option>UX / UI Designer</option>
+                </optgroup>
+                <optgroup label="Status">
+                  <option>Student / Bootcamp</option>
+                  <option>Career Changer</option>
+                  <option>Freelancer / Consultant</option>
+                  <option>Other</option>
+                </optgroup>
+              </select>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Experience level</label>
+            <div class="card-grid">
+              <button
+                v-for="opt in levelOptions" :key="opt.value" type="button"
+                class="option-card" :class="form.level === opt.value ? 'option-card--active' : ''"
+                @click="form.level = opt.value"
+              >
+                <span class="option-card__icon">{{ opt.icon }}</span>
+                <span class="option-card__label">{{ opt.label }}</span>
+                <span class="option-card__sub">{{ opt.sub }}</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="step-actions">
+            <button class="btn-primary" :disabled="!step1Valid" @click="next">
+              Continue <UIcon name="i-heroicons-arrow-right" class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </Transition>
+
+      <!-- ── STEP 2 — What you're looking for ──────────────── -->
+      <Transition :name="transitionName" mode="out-in">
+        <div v-if="step === 2" key="2" class="step-body">
+          <h2 class="step-title">What are you looking for?</h2>
+
+          <div class="field">
+            <label>Choose the product that fits your goal</label>
+            <div class="product-grid">
+              <button
+                v-for="opt in productOptions" :key="opt.value" type="button"
+                class="product-card" :class="form.product_interest === opt.value ? 'product-card--active' : ''"
+                @click="form.product_interest = opt.value"
+              >
+                <span class="product-card__icon">{{ opt.icon }}</span>
+                <p class="product-card__label">{{ opt.label }}</p>
+                <p class="product-card__desc">{{ opt.desc }}</p>
+                <p class="product-card__price">{{ opt.price }}</p>
+              </button>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>When do you want to see results?</label>
+            <div class="tag-row">
+              <button
+                v-for="opt in timelineOptions" :key="opt.value" type="button"
+                class="tag-btn" :class="form.timeline === opt.value ? 'tag-btn--active' : ''"
+                @click="form.timeline = opt.value"
+              >{{ opt.label }}</button>
+            </div>
+          </div>
+
+          <div class="step-actions">
+            <button class="btn-ghost" @click="prev">
+              <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" /> Back
+            </button>
+            <button class="btn-primary" :disabled="!step2Valid" @click="next">
+              Continue <UIcon name="i-heroicons-arrow-right" class="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </Transition>
+
+      <!-- ── STEP 3 — Your situation ───────────────────────── -->
+      <Transition :name="transitionName" mode="out-in">
+        <div v-if="step === 3" key="3" class="step-body">
+          <h2 class="step-title">Your situation</h2>
+
+          <div class="field">
+            <label>Main stack <span class="label-hint">(select all that apply)</span></label>
+            <div class="tag-row tag-row--wrap">
+              <button
+                v-for="s in stackOptions" :key="s" type="button"
+                class="tag-btn" :class="form.stack.includes(s) ? 'tag-btn--active' : ''"
+                @click="toggleStack(s)"
+              >{{ s }}</button>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Hours available per week</label>
+            <div class="tag-row">
+              <button
+                v-for="opt in availabilityOptions" :key="opt.value" type="button"
+                class="tag-btn" :class="form.availability_hours === opt.value ? 'tag-btn--active' : ''"
+                @click="form.availability_hours = opt.value"
+              >{{ opt.label }}</button>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Anything else you'd like us to know? <span class="label-hint">(optional)</span></label>
+            <div class="field__wrap field__wrap--textarea">
+              <textarea
+                v-model="form.goal" rows="3" maxlength="500"
+                placeholder="Your current situation, specific challenges, what you've tried before…"
+              ></textarea>
+              <span class="char-count">{{ form.goal.length }}/500</span>
+            </div>
+          </div>
+
+          <Transition name="err">
+            <div v-if="error" class="alert" role="alert">
+              <UIcon name="i-heroicons-exclamation-circle" class="alert__ico" />
+              {{ error }}
+            </div>
+          </Transition>
+
+          <div class="step-actions">
+            <button class="btn-ghost" @click="prev">
+              <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" /> Back
+            </button>
+            <button class="btn-primary" :disabled="loading || !step3Valid" @click="handleSubmit">
+              <span v-if="!loading">Complete setup</span>
+              <span v-else class="spinner-row">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"
+                    stroke-dasharray="40 20" stroke-linecap="round"
+                    style="transform-origin:center;animation:spin .8s linear infinite"/>
+                </svg>
+                Saving…
+              </span>
+            </button>
+          </div>
+
+          <button type="button" class="btn-skip" @click="navigateTo('/dashboard')">
+            Skip for now
+          </button>
+        </div>
+      </Transition>
+
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: false, middleware: 'auth' })
+useHead({ title: 'Welcome — CODECV' })
+
+const { user, updateUser } = useAuth()
+const { patch } = useApi()
+
+const step           = ref(1)
+const transitionName = ref('slide-left')
+const loading        = ref(false)
+const error          = ref('')
+
+const form = reactive({
+  profession:         '',
+  level:              '' as string,
+  stack:              [] as string[],
+  product_interest:   '' as string,
+  availability_hours: null as number | null,
+  timeline:           '' as string,
+  goal:               '',
+})
+
+// ── Options ────────────────────────────────────────────────
+const levelOptions = [
+  { value: 'junior',  icon: '🌱', label: 'Júnior',  sub: '0–2 years' },
+  { value: 'mid',     icon: '⚡', label: 'Pleno',   sub: '2–5 years' },
+  { value: 'senior',  icon: '🚀', label: 'Sênior',  sub: '5+ years'  },
+  { value: 'manager', icon: '🎯', label: 'Manager', sub: 'Tech Lead / Manager' },
+]
+
+const productOptions = [
+  {
+    value: 'self-serve',
+    icon:  '📄',
+    label: 'Career Accelerator',
+    desc:  'CV review, LinkedIn optimisation, interview prep',
+    price: 'From €99/month',
+  },
+  {
+    value: 'bootcamp',
+    icon:  '🧑‍💻',
+    label: 'Laravel Bootcamp',
+    desc:  'Laravel + New Relic · 12–16 weeks · cohort-based',
+    price: '€2,500–5,000',
+  },
+  {
+    value: 'mentorship',
+    icon:  '🎓',
+    label: '1-on-1 Mentorship',
+    desc:  'Bi-weekly sessions, personalised roadmap',
+    price: '€800–1,500/month',
+  },
+]
+
+const timelineOptions = [
+  { value: '1-3m',     label: '1–3 months'  },
+  { value: '3-6m',     label: '3–6 months'  },
+  { value: '6-12m',    label: '6–12 months' },
+  { value: 'flexible', label: 'No rush'     },
+]
+
+const stackOptions = [
+  'Laravel/PHP', 'React', 'Vue.js', 'Node.js',
+  'TypeScript', 'Python', 'DevOps/Cloud', 'Mobile',
+  'Java/Spring', 'Other',
+]
+
+const availabilityOptions = [
+  { value: 5,  label: '~5h/week'  },
+  { value: 10, label: '~10h/week' },
+  { value: 20, label: '~20h/week' },
+  { value: 40, label: '40h+ week' },
+]
+
+// ── Validation ─────────────────────────────────────────────
+const step1Valid = computed(() => form.profession && form.level)
+const step2Valid = computed(() => form.product_interest && form.timeline)
+const step3Valid = computed(() => form.stack.length > 0 && form.availability_hours !== null)
+
+// ── Navigation ─────────────────────────────────────────────
+function next() {
+  transitionName.value = 'slide-left'
+  step.value++
+}
+function prev() {
+  transitionName.value = 'slide-right'
+  step.value--
+}
+
+function stepClass(i: number) {
+  if (i < step.value)  return 'step-circle--done'
+  if (i === step.value) return 'step-circle--active'
+  return ''
+}
+
+function toggleStack(s: string) {
+  const idx = form.stack.indexOf(s)
+  if (idx === -1) form.stack.push(s)
+  else form.stack.splice(idx, 1)
+}
+
+// ── Submit ──────────────────────────────────────────────────
+async function handleSubmit() {
+  loading.value = true
+  error.value   = ''
+  try {
+    const res = await patch<{ message: string; user: any }>('/me/onboarding', { ...form })
+    updateUser(res.user)
+    navigateTo('/dashboard')
+  } catch (e: any) {
+    error.value = e?.data?.message || 'Something went wrong. Please try again.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+.onboarding-page {
+  --accent:  #6366f1;
+  --glow:    rgba(99,102,241,0.18);
+  --error:   #ef4444;
+  --font:    'Inter', system-ui, sans-serif;
+  --ease:    cubic-bezier(0.16,1,0.3,1);
+  font-family: var(--font);
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  background: linear-gradient(135deg, #f0f4ff 0%, #e8f4f8 100%);
+}
+
+.onboarding-card {
+  width: 100%;
+  max-width: 580px;
+  background: #fff;
+  border-radius: 20px;
+  padding: 2.5rem;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.1), 0 4px 16px rgba(0,0,0,0.05);
+}
+
+/* Header */
+.card-header { text-align: center; margin-bottom: 1.75rem; }
+.logo-link { display: inline-block; margin-bottom: 1rem; }
+.logo { height: 44px; width: auto; mix-blend-mode: multiply; }
+.card-header h1 { font-size: 1.5rem; font-weight: 800; color: #0f172a; letter-spacing: -0.02em; margin-bottom: 0.35rem; }
+.card-header p  { font-size: 0.875rem; color: #64748b; }
+
+/* Step indicator */
+.steps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  margin-bottom: 2rem;
+}
+.step-item { display: flex; align-items: center; }
+.step-circle {
+  width: 28px; height: 28px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 0.75rem; font-weight: 700;
+  background: #f1f5f9; color: #94a3b8;
+  border: 2px solid #e2e8f0;
+  transition: all .25s var(--ease);
+}
+.step-circle--active {
+  background: var(--accent); color: #fff; border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(99,102,241,0.15);
+}
+.step-circle--done { background: #10b981; color: #fff; border-color: #10b981; }
+.step-line {
+  width: 48px; height: 2px;
+  background: #e2e8f0; transition: background .25s;
+}
+.step-line--done { background: #10b981; }
+
+/* Step body */
+.step-body { animation: rise .35s var(--ease) both; }
+@keyframes rise { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
+
+.step-title {
+  font-size: 1.1rem; font-weight: 700; color: #0f172a;
+  margin-bottom: 1.5rem;
+}
+
+/* Fields */
+.field { margin-bottom: 1.5rem; }
+.field label {
+  display: block; font-size: 0.82rem; font-weight: 600;
+  color: #374151; margin-bottom: 0.6rem;
+}
+.label-hint { font-weight: 400; color: #94a3b8; }
+.field__wrap { position: relative; }
+.field__ico {
+  position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%);
+  width: 16px; height: 16px; color: #9ca3af; pointer-events: none;
+}
+
+select {
+  width: 100%; background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 10px;
+  padding: 0.8rem 0.9rem 0.8rem 2.6rem; font-family: var(--font); font-size: 0.9375rem;
+  color: #0f172a; outline: none; cursor: pointer; appearance: none;
+  transition: border-color .15s, box-shadow .15s;
+}
+select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--glow); background: #fff; }
+
+/* Level cards */
+.card-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.6rem; }
+.option-card {
+  display: flex; flex-direction: column; align-items: center; gap: 0.2rem;
+  padding: 0.9rem 0.5rem; border-radius: 10px; border: 1.5px solid #e2e8f0;
+  background: #f8fafc; cursor: pointer; transition: all .15s;
+  font-family: var(--font);
+}
+.option-card:hover { border-color: #a5b4fc; background: #eef2ff; }
+.option-card--active { border-color: var(--accent); background: #eef2ff; box-shadow: 0 0 0 3px var(--glow); }
+.option-card__icon  { font-size: 1.4rem; }
+.option-card__label { font-size: 0.8rem; font-weight: 700; color: #0f172a; }
+.option-card__sub   { font-size: 0.65rem; color: #94a3b8; text-align: center; }
+
+/* Product cards */
+.product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; }
+.product-card {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 0.3rem;
+  padding: 1rem; border-radius: 12px; border: 1.5px solid #e2e8f0;
+  background: #f8fafc; cursor: pointer; transition: all .15s;
+  font-family: var(--font); text-align: left;
+}
+.product-card:hover { border-color: #a5b4fc; background: #eef2ff; }
+.product-card--active { border-color: var(--accent); background: #eef2ff; box-shadow: 0 0 0 3px var(--glow); }
+.product-card__icon  { font-size: 1.5rem; }
+.product-card__label { font-size: 0.82rem; font-weight: 700; color: #0f172a; }
+.product-card__desc  { font-size: 0.7rem; color: #64748b; line-height: 1.4; }
+.product-card__price { font-size: 0.7rem; font-weight: 600; color: var(--accent); margin-top: auto; padding-top: 0.4rem; }
+
+/* Tag buttons */
+.tag-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.tag-row--wrap { }
+.tag-btn {
+  padding: 0.45rem 0.9rem; border-radius: 99px; border: 1.5px solid #e2e8f0;
+  background: #f8fafc; font-family: var(--font); font-size: 0.82rem;
+  font-weight: 500; color: #475569; cursor: pointer; transition: all .15s;
+}
+.tag-btn:hover { border-color: #a5b4fc; color: var(--accent); }
+.tag-btn--active { border-color: var(--accent); background: #eef2ff; color: var(--accent); font-weight: 600; }
+
+/* Textarea */
+.field__wrap--textarea { display: flex; flex-direction: column; }
+textarea {
+  width: 100%; background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 10px;
+  padding: 0.8rem; font-family: var(--font); font-size: 0.9375rem;
+  color: #0f172a; outline: none; resize: vertical; min-height: 90px;
+  transition: border-color .15s, box-shadow .15s;
+}
+textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--glow); background: #fff; }
+textarea::placeholder { color: #c0c9d4; }
+.char-count { align-self: flex-end; font-size: 0.7rem; color: #94a3b8; margin-top: 0.25rem; }
+
+/* Actions */
+.step-actions {
+  display: flex; justify-content: flex-end; gap: 0.75rem;
+  margin-top: 1.75rem;
+}
+.btn-primary {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.75rem 1.5rem; background: var(--accent); color: #fff;
+  font-family: var(--font); font-size: 0.9375rem; font-weight: 700;
+  border: none; border-radius: 10px; cursor: pointer;
+  transition: background .2s, transform .15s, box-shadow .2s;
+}
+.btn-primary:hover:not(:disabled) {
+  background: #4f46e5; transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(99,102,241,0.35);
+}
+.btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
+.btn-ghost {
+  display: flex; align-items: center; gap: 0.4rem;
+  padding: 0.75rem 1rem; background: none;
+  font-family: var(--font); font-size: 0.875rem; font-weight: 500;
+  color: #64748b; border: 1.5px solid #e2e8f0; border-radius: 10px;
+  cursor: pointer; transition: all .15s;
+}
+.btn-ghost:hover { border-color: #94a3b8; color: #374151; }
+.btn-skip {
+  display: block; width: 100%; margin-top: 0.75rem;
+  padding: 0.6rem; background: none; color: #94a3b8;
+  font-family: var(--font); font-size: 0.8rem;
+  border: none; cursor: pointer; transition: color .15s;
+}
+.btn-skip:hover { color: #64748b; }
+
+/* Alert */
+.alert {
+  display: flex; align-items: center; gap: 0.6rem;
+  padding: 0.75rem 1rem; background: #fef2f2; border: 1px solid #fecaca;
+  border-radius: 10px; font-size: 0.875rem; color: var(--error);
+  margin-bottom: 1rem;
+}
+.alert__ico { width: 15px; height: 15px; flex-shrink: 0; }
+.err-enter-active { animation: errIn .3s var(--ease); }
+@keyframes errIn { from { opacity:0; transform:translateY(-4px); } to { opacity:1; transform:translateY(0); } }
+
+/* Slide transitions */
+.slide-left-enter-active,
+.slide-left-leave-active,
+.slide-right-enter-active,
+.slide-right-leave-active { transition: all .25s var(--ease); }
+
+.slide-left-enter-from  { opacity: 0; transform: translateX(30px); }
+.slide-left-leave-to    { opacity: 0; transform: translateX(-30px); }
+.slide-right-enter-from { opacity: 0; transform: translateX(-30px); }
+.slide-right-leave-to   { opacity: 0; transform: translateX(30px); }
+
+.spinner-row { display: flex; align-items: center; gap: 0.5rem; }
+.spinner-row svg { width: 16px; height: 16px; }
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Responsive */
+@media (max-width: 500px) {
+  .onboarding-card { padding: 1.75rem 1.25rem; }
+  .card-grid { grid-template-columns: repeat(2, 1fr); }
+  .product-grid { grid-template-columns: 1fr; }
+}
+</style>

--- a/frontend/pages/register.vue
+++ b/frontend/pages/register.vue
@@ -184,7 +184,7 @@ async function handleRegister() {
   error.value   = ''
   const result = await register({ ...form })
   loading.value = false
-  if (result.success) navigateTo('/dashboard')
+  if (result.success) navigateTo('/onboarding')
   else {
     error.value = result.error || 'Registration failed.'
     form.password = ''

--- a/frontend/pages/users/[id].vue
+++ b/frontend/pages/users/[id].vue
@@ -70,8 +70,10 @@
         </div>
       </UCard>
 
-      <!-- Details Card -->
+      <!-- Details -->
       <div class="lg:col-span-2 space-y-6">
+
+        <!-- Account Details -->
         <UCard>
           <template #header>
             <h3 class="font-semibold text-gray-900 dark:text-white">Account Details</h3>
@@ -90,15 +92,105 @@
               <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">{{ selectedUser.profile?.birth_date || 'N/A' }}</p>
             </div>
             <div>
-              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Profession</label>
-              <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">{{ selectedUser.profile?.profession || 'N/A' }}</p>
-            </div>
-            <div>
               <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Member Since</label>
               <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">{{ formatDate(selectedUser.created_at) }}</p>
             </div>
           </div>
         </UCard>
+
+        <!-- Career Profile -->
+        <UCard v-if="hasOnboarding">
+          <template #header>
+            <h3 class="font-semibold text-gray-900 dark:text-white">Career Profile</h3>
+          </template>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Role</label>
+              <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">
+                {{ selectedUser.profile?.profession || 'N/A' }}
+              </p>
+            </div>
+            <div>
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Level</label>
+              <p class="mt-1 pb-2 border-b dark:border-gray-800">
+                <UBadge :color="levelColor(selectedUser.profile?.level)" variant="subtle" class="capitalize">
+                  {{ selectedUser.profile?.level || 'N/A' }}
+                </UBadge>
+              </p>
+            </div>
+            <div>
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Product Interest</label>
+              <p class="mt-1 pb-2 border-b dark:border-gray-800">
+                <UBadge :color="productColor(selectedUser.profile?.product_interest)" variant="subtle">
+                  {{ productLabel(selectedUser.profile?.product_interest) }}
+                </UBadge>
+              </p>
+            </div>
+            <div>
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Timeline</label>
+              <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">
+                {{ timelineLabel(selectedUser.profile?.timeline) }}
+              </p>
+            </div>
+            <div>
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Availability</label>
+              <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">
+                {{ selectedUser.profile?.availability_hours ? `${selectedUser.profile.availability_hours}h / week` : 'N/A' }}
+              </p>
+            </div>
+            <div v-if="selectedUser.profile?.goal">
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Goal</label>
+              <p class="text-gray-900 dark:text-white font-medium border-b dark:border-gray-800 pb-2 mt-1">
+                {{ selectedUser.profile.goal }}
+              </p>
+            </div>
+            <div class="md:col-span-2" v-if="selectedUser.profile?.stack?.length">
+              <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Stack</label>
+              <div class="flex flex-wrap gap-2 mt-2">
+                <UBadge v-for="s in selectedUser.profile.stack" :key="s" color="indigo" variant="subtle">
+                  {{ s }}
+                </UBadge>
+              </div>
+            </div>
+          </div>
+        </UCard>
+
+        <!-- Onboarding pending notice -->
+        <UAlert v-else color="amber" variant="subtle"
+          icon="i-heroicons-clock"
+          title="Onboarding not completed"
+          description="This user has not filled in their career profile yet." />
+
+        <!-- Assign Consultant (admin only) -->
+        <UCard v-if="isAdmin">
+          <template #header>
+            <h3 class="font-semibold text-gray-900 dark:text-white">Assigned Consultant</h3>
+          </template>
+
+          <div v-if="selectedUser.consultant" class="flex items-center gap-3 mb-4">
+            <UAvatar :alt="selectedUser.consultant.fullname" size="sm" />
+            <div>
+              <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ selectedUser.consultant.fullname }}</p>
+              <p class="text-xs text-gray-400">{{ selectedUser.consultant.email }}</p>
+            </div>
+          </div>
+          <p v-else class="text-sm text-gray-400 mb-4">No consultant assigned yet.</p>
+
+          <div class="flex gap-3">
+            <select v-model="selectedConsultantId" class="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-gray-900 dark:text-white">
+              <option :value="null">— Remove assignment —</option>
+              <option v-for="c in consultants" :key="c.id" :value="c.id">{{ c.fullname }}</option>
+            </select>
+            <UButton
+              :loading="assigningConsultant"
+              :disabled="selectedConsultantId === selectedUser.consultant_id"
+              @click="handleAssignConsultant"
+            >
+              Save
+            </UButton>
+          </div>
+        </UCard>
+
       </div>
     </div>
   </NuxtLayout>
@@ -113,6 +205,38 @@ definePageMeta({
 const route = useRoute()
 const userId = computed(() => Number(route.params.id))
 const { user: selectedUser, loading, error: fetchError, fetchUser } = useUsers()
+const { get, patch } = useApi()
+const { isAdmin } = useAuth()
+const toast = useToast()
+
+const consultants          = ref<any[]>([])
+const selectedConsultantId = ref<number | null>(null)
+const assigningConsultant  = ref(false)
+
+async function loadConsultants() {
+  try {
+    const res = await get<{ data: any[] }>('/consultants')
+    consultants.value = res.data
+  } catch {}
+}
+
+async function handleAssignConsultant() {
+  assigningConsultant.value = true
+  try {
+    const res = await patch<{ user: any }>(`/users/${userId.value}/consultant`, {
+      consultant_id: selectedConsultantId.value,
+    })
+    if (selectedUser.value) selectedUser.value = res.user
+    selectedConsultantId.value = res.user.consultant_id ?? null
+    toast.add({ title: 'Consultant assigned', color: 'green' })
+  } catch (e: any) {
+    toast.add({ title: e?.data?.message || 'Failed to assign consultant', color: 'red' })
+  } finally {
+    assigningConsultant.value = false
+  }
+}
+
+const hasOnboarding = computed(() => !!selectedUser.value?.profile?.level)
 
 const roleBadgeColor = (role?: string) => {
   switch (role) {
@@ -122,7 +246,49 @@ const roleBadgeColor = (role?: string) => {
   }
 }
 
+const levelColor = (level?: string) => {
+  switch (level) {
+    case 'junior':  return 'green'
+    case 'mid':     return 'blue'
+    case 'senior':  return 'purple'
+    case 'manager': return 'orange'
+    default: return 'gray'
+  }
+}
+
+const productColor = (p?: string) => {
+  switch (p) {
+    case 'self-serve':  return 'green'
+    case 'bootcamp':    return 'blue'
+    case 'mentorship':  return 'purple'
+    default: return 'gray'
+  }
+}
+
+const productLabel = (p?: string) => {
+  switch (p) {
+    case 'self-serve':  return 'Career Accelerator'
+    case 'bootcamp':    return 'Laravel Bootcamp'
+    case 'mentorship':  return '1-on-1 Mentorship'
+    default: return 'N/A'
+  }
+}
+
+const timelineLabel = (t?: string) => {
+  switch (t) {
+    case '1-3m':     return '1–3 months'
+    case '3-6m':     return '3–6 months'
+    case '6-12m':    return '6–12 months'
+    case 'flexible': return 'No rush'
+    default: return 'N/A'
+  }
+}
+
 const formatDate = (date: string) => new Date(date).toLocaleDateString()
 
-onMounted(() => fetchUser(userId.value))
+onMounted(async () => {
+  await fetchUser(userId.value)
+  selectedConsultantId.value = selectedUser.value?.consultant_id ?? null
+  if (isAdmin.value) loadConsultants()
+})
 </script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\SocialAuthController;
 use App\Http\Controllers\Api\PasswordResetController;
 use App\Http\Controllers\Api\CourseController;
@@ -61,6 +62,14 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::post('/cv/analyze', [CvController::class, 'analyze']);
     Route::post('/linkedin/analyze', [LinkedInController::class, 'analyze']);
 
+    // Notifications
+    Route::get('/notifications', [NotificationController::class, 'index']);
+    Route::patch('/notifications/{id}/read', [NotificationController::class, 'markRead']);
+    Route::patch('/notifications/read-all', [NotificationController::class, 'markAllRead']);
+
+    // Onboarding (authenticated user completes their own profile)
+    Route::patch('/me/onboarding', [UserController::class, 'completeOnboarding']);
+
     // User self-service (admin or resource owner — enforced in controller)
     Route::get('/users/{user}', [UserController::class, 'show']);
     Route::put('/users/{user}', [UserController::class, 'update']);
@@ -107,6 +116,8 @@ Route::middleware(['auth:sanctum'])->group(function () {
         Route::get('/users', [UserController::class, 'index']);
         Route::post('/users', [UserController::class, 'store']);
         Route::delete('/users/{user}', [UserController::class, 'destroy']);
+        Route::get('/consultants', [UserController::class, 'consultants']);
+        Route::patch('/users/{user}/consultant', [UserController::class, 'assignConsultant']);
         Route::get('/roles', [RoleController::class, 'index']);
     });
 });


### PR DESCRIPTION
## Summary

- **Onboarding wizard** (3 steps): collects profession, level, stack, product interest, availability and timeline — gives admin actionable data per client instead of just a name and email
- **In-app notifications**: bell icon in admin topbar shows real notifications when a client completes onboarding; click navigates to the user profile and marks as read
- **Assign Consultant**: admin can assign or remove a consultant directly from `/users/{id}` — closes the operational loop after receiving a notification
- **User profile page**: new "Career Profile" card shows all onboarding fields with coloured badges; shows amber alert if onboarding not completed
- **Auth redirects**: register and Google OAuth callback now send new users to `/onboarding` instead of `/dashboard`

## Migrations

- `add_goal_to_profiles_table`
- `add_email_verified_at_to_users_table`
- `create_notifications_table` (Laravel database notifications)
- `add_onboarding_fields_to_profiles_table` — level, stack (JSON), product_interest, availability_hours, timeline

## Test plan

- [ ] Register new account → lands on `/onboarding` wizard
- [ ] Complete all 3 steps → redirects to `/dashboard`
- [ ] Login as admin → bell shows notification with career data
- [ ] Click notification → navigates to user profile, marks as read
- [ ] Admin assigns consultant on user profile → toast confirmation
- [ ] Google OAuth new user → lands on `/onboarding`; existing user with profile → `/dashboard`
- [ ] `lando php vendor/bin/phpunit` — 360 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)