### PR TITLE
feat(roadmap): visual roadmap with Vue Flow, 3D effects and glassmorphism

### DIFF
--- a/frontend/components/RoadmapFlow.vue
+++ b/frontend/components/RoadmapFlow.vue
@@ -1,0 +1,180 @@
+<template>
+  <ClientOnly>
+    <div class="rf-wrap" :style="{ height: wrapHeight }">
+      <VueFlow
+        :nodes="nodes"
+        :edges="edges"
+        :node-types="nodeTypes"
+        fit-view-on-init
+        :min-zoom="0.3"
+        :max-zoom="1.8"
+        :nodes-draggable="false"
+        :nodes-connectable="false"
+        :elements-selectable="false"
+        class="rf-flow"
+        @node-click="onNodeClick"
+      >
+        <!-- Dark dot grid -->
+        <Background
+          variant="dots"
+          :gap="28"
+          :size="1.2"
+          pattern-color="rgba(99,102,241,0.2)"
+        />
+
+        <!-- Minimap for long paths -->
+        <MiniMap
+          v-if="steps.length > 5"
+          :node-color="minimapColor"
+          :mask-color="'rgba(0,0,0,0.6)'"
+          class="rf-minimap"
+        />
+
+        <Controls :show-interactive="false" class="rf-controls" />
+      </VueFlow>
+    </div>
+
+    <template #fallback>
+      <div class="rf-fallback">Loading roadmap…</div>
+    </template>
+  </ClientOnly>
+</template>
+
+<script setup lang="ts">
+import { VueFlow } from '@vue-flow/core'
+import { Background } from '@vue-flow/background'
+import { MiniMap } from '@vue-flow/minimap'
+import { Controls } from '@vue-flow/controls'
+import '@vue-flow/core/dist/style.css'
+import '@vue-flow/core/dist/theme-default.css'
+import '@vue-flow/minimap/dist/style.css'
+import '@vue-flow/controls/dist/style.css'
+import RoadmapStepNode from '~/components/RoadmapStepNode.vue'
+
+interface Step {
+  id: number
+  title: string
+  order: number
+  course?: { id: number; name: string } | null
+  resources?: any[]
+  user_status?: 'not_started' | 'in_progress' | 'done'
+}
+
+const props = defineProps<{ steps: Step[] }>()
+const emit  = defineEmits<{ (e: 'nodeClick', step: Step): void }>()
+
+const nodeTypes = { step: markRaw(RoadmapStepNode) }
+
+const NODE_H = 100
+const GAP    = 52
+
+const nodes = computed(() =>
+  props.steps.map((step, i) => ({
+    id:       String(step.id),
+    type:     'step',
+    position: { x: 0, y: i * (NODE_H + GAP) },
+    data: {
+      order:         step.order ?? i + 1,
+      title:         step.title,
+      course:        step.course?.name ?? null,
+      resourceCount: (step.resources ?? []).length,
+      status:        step.user_status,
+      step,
+    },
+  }))
+)
+
+const edges = computed(() =>
+  props.steps.slice(0, -1).map((step, i) => {
+    const next   = props.steps[i + 1]
+    const isDone = step.user_status === 'done'
+    const isWip  = step.user_status === 'in_progress'
+    return {
+      id:        `e${step.id}-${next.id}`,
+      source:    String(step.id),
+      target:    String(next.id),
+      animated:  isWip,
+      type:      'smoothstep',
+      style: {
+        stroke:      isDone ? '#22c55e' : isWip ? '#818cf8' : 'rgba(99,102,241,0.35)',
+        strokeWidth: isDone || isWip ? 2.5 : 1.5,
+        filter:      isDone ? 'drop-shadow(0 0 4px #22c55e)' : isWip ? 'drop-shadow(0 0 6px #818cf8)' : 'none',
+      },
+      markerEnd: {
+        type:   'arrowclosed',
+        color:  isDone ? '#22c55e' : isWip ? '#818cf8' : 'rgba(99,102,241,0.4)',
+        width:  12,
+        height: 12,
+      },
+    }
+  })
+)
+
+const wrapHeight = computed(() => {
+  const h = props.steps.length * (NODE_H + GAP) + 120
+  return `${Math.max(h, 340)}px`
+})
+
+function minimapColor(node: any) {
+  const s = node.data?.status
+  if (s === 'done')        return '#22c55e'
+  if (s === 'in_progress') return '#6366f1'
+  return '#334155'
+}
+
+function onNodeClick({ node }: any) {
+  emit('nodeClick', node.data.step)
+}
+</script>
+
+<style>
+/* ── Canvas ──────────────────────────────────────────── */
+.rf-wrap {
+  width: 100%;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(99,102,241,0.2);
+  background:
+    radial-gradient(ellipse at 20% 10%,  rgba(99,102,241,0.12) 0%, transparent 45%),
+    radial-gradient(ellipse at 80% 80%,  rgba(6,182,212,0.08)  0%, transparent 45%),
+    radial-gradient(ellipse at 60% 40%,  rgba(139,92,246,0.07) 0%, transparent 40%),
+    #060d1a;
+}
+
+.rf-flow { width: 100%; height: 100%; }
+
+/* Override VueFlow internals to fit dark theme */
+.rf-flow .vue-flow__background { background: transparent !important; }
+.rf-flow .vue-flow__pane       { cursor: grab; }
+.rf-flow .vue-flow__pane:active { cursor: grabbing; }
+
+/* Minimap */
+.rf-minimap {
+  border-radius: 10px !important;
+  overflow: hidden;
+  border: 1px solid rgba(99,102,241,0.25) !important;
+  background: rgba(6,13,26,0.9) !important;
+}
+
+/* Controls */
+.rf-controls {
+  border-radius: 10px !important;
+  overflow: hidden;
+  border: 1px solid rgba(99,102,241,0.25) !important;
+  background: rgba(15,23,42,0.9) !important;
+  box-shadow: none !important;
+}
+.rf-controls button {
+  background: transparent !important;
+  border-bottom: 1px solid rgba(99,102,241,0.15) !important;
+  color: #94a3b8 !important;
+}
+.rf-controls button:hover { background: rgba(99,102,241,0.15) !important; color: #a5b4fc !important; }
+.rf-controls button:last-child { border-bottom: none !important; }
+
+/* Fallback */
+.rf-fallback {
+  display: flex; align-items: center; justify-content: center;
+  height: 240px; font-size: 0.875rem; color: #64748b;
+}
+</style>

--- a/frontend/components/RoadmapStepNode.vue
+++ b/frontend/components/RoadmapStepNode.vue
@@ -1,0 +1,308 @@
+<template>
+  <div
+    class="rn"
+    :class="[`rn--${status}`, entered && 'rn--entered']"
+    @mouseenter="onEnter"
+    @mouseleave="onLeave"
+    @mousemove="onMove"
+    :style="tiltStyle"
+  >
+    <!-- Animated gradient border for in_progress -->
+    <div v-if="status === 'in_progress'" class="rn__border-anim" />
+
+    <!-- Glass surface -->
+    <div class="rn__glass" />
+
+    <!-- Inner shine highlight -->
+    <div class="rn__shine" :style="shineStyle" />
+
+    <!-- Content -->
+    <div class="rn__content">
+      <!-- Badge + title row -->
+      <div class="rn__header">
+        <div class="rn__badge" :class="`rn__badge--${status}`">
+          <svg v-if="status === 'done'" viewBox="0 0 14 14" fill="none" class="rn__check">
+            <path d="M2 7l4 4 6-6" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <svg v-else-if="status === 'in_progress'" viewBox="0 0 14 14" fill="none" class="rn__check">
+            <circle cx="7" cy="7" r="3" fill="currentColor"/>
+          </svg>
+          <span v-else class="rn__num">{{ data.order }}</span>
+        </div>
+
+        <p class="rn__title" :class="status === 'done' && 'rn__title--done'">
+          {{ data.title }}
+        </p>
+      </div>
+
+      <!-- Meta row -->
+      <div class="rn__meta">
+        <span v-if="data.course" class="rn__tag rn__tag--course">
+          <svg viewBox="0 0 12 12" fill="none"><path d="M1 3l5 2.5L11 3M1 3v6l5 2.5M1 3l5-2.5L11 3v6L6 11.5" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/></svg>
+          {{ data.course }}
+        </span>
+        <span v-if="data.resourceCount" class="rn__tag rn__tag--res">
+          <svg viewBox="0 0 12 12" fill="none"><path d="M3 6h6M3 3.5h6M3 8.5h4" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
+          {{ data.resourceCount }}
+        </span>
+        <span class="rn__tag" :class="`rn__tag--${status}`">{{ statusLabel }}</span>
+      </div>
+    </div>
+
+    <!-- Glow orb -->
+    <div class="rn__orb" :class="`rn__orb--${status}`" />
+
+    <Handle type="target" :position="Position.Top"    style="opacity:0;pointer-events:none;background:transparent;border:none" />
+    <Handle type="source" :position="Position.Bottom" style="opacity:0;pointer-events:none;background:transparent;border:none" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Handle, Position } from '@vue-flow/core'
+
+const props = defineProps<{
+  data: {
+    order: number
+    title: string
+    course?: string | null
+    resourceCount?: number
+    status?: 'not_started' | 'in_progress' | 'done'
+    step: any
+  }
+}>()
+
+defineEmits(['click'])
+
+const status = computed(() => props.data.status ?? 'not_started')
+
+const statusLabel = computed(() => ({
+  done:        'Done',
+  in_progress: 'In Progress',
+  not_started: 'Not Started',
+}[status.value]))
+
+// ── 3D tilt ──────────────────────────────────────────────
+const tiltX    = ref(0)
+const tiltY    = ref(0)
+const shineX   = ref(50)
+const shineY   = ref(50)
+const entered  = ref(false)
+let   raf      = 0
+
+function onEnter() { entered.value = true }
+function onLeave() {
+  cancelAnimationFrame(raf)
+  raf = requestAnimationFrame(() => {
+    tiltX.value  = 0
+    tiltY.value  = 0
+    shineX.value = 50
+    shineY.value = 50
+  })
+}
+
+function onMove(e: MouseEvent) {
+  const el   = e.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  const x    = (e.clientX - rect.left) / rect.width   // 0-1
+  const y    = (e.clientY - rect.top)  / rect.height  // 0-1
+  raf = requestAnimationFrame(() => {
+    tiltY.value  =  (x - 0.5) * 16
+    tiltX.value  = -(y - 0.5) * 10
+    shineX.value = x * 100
+    shineY.value = y * 100
+  })
+}
+
+const tiltStyle = computed(() => ({
+  transform: `perspective(900px) rotateX(${tiltX.value}deg) rotateY(${tiltY.value}deg) translateZ(0)`,
+}))
+
+const shineStyle = computed(() => ({
+  background: `radial-gradient(circle at ${shineX.value}% ${shineY.value}%, rgba(255,255,255,0.18) 0%, transparent 65%)`,
+}))
+</script>
+
+<style scoped>
+/* ── Root ─────────────────────────────────────────────── */
+.rn {
+  position: relative;
+  width: 290px;
+  border-radius: 16px;
+  padding: 14px 16px;
+  cursor: pointer;
+  isolation: isolate;
+  overflow: hidden;
+  transition: transform 0.08s linear, box-shadow 0.25s ease;
+  will-change: transform;
+  opacity: 0;
+  translate: 0 12px;
+}
+.rn--entered {
+  opacity: 1;
+  translate: 0 0;
+  transition: opacity 0.4s ease, translate 0.4s ease, transform 0.08s linear, box-shadow 0.25s ease;
+}
+
+/* Status variants */
+.rn--not_started {
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06);
+}
+.rn--in_progress {
+  background: rgba(15, 23, 42, 0.80);
+  border: 1px solid transparent;
+  box-shadow: 0 4px 32px rgba(99,102,241,0.25), 0 0 60px rgba(99,102,241,0.08);
+}
+.rn--done {
+  background: rgba(5, 46, 22, 0.65);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  box-shadow: 0 4px 24px rgba(34,197,94,0.18), inset 0 1px 0 rgba(255,255,255,0.05);
+}
+
+.rn--not_started:hover { box-shadow: 0 16px 40px rgba(0,0,0,0.6), 0 0 30px rgba(99,102,241,0.2); }
+.rn--in_progress:hover { box-shadow: 0 16px 48px rgba(99,102,241,0.4), 0 0 60px rgba(99,102,241,0.15); }
+.rn--done:hover        { box-shadow: 0 16px 40px rgba(34,197,94,0.3), 0 0 40px rgba(34,197,94,0.12); }
+
+/* ── Animated gradient border (in_progress) ──────────── */
+.rn__border-anim {
+  position: absolute;
+  inset: -2px;
+  border-radius: 18px;
+  z-index: -1;
+  background: conic-gradient(from var(--angle, 0deg), #6366f1, #06b6d4, #8b5cf6, #ec4899, #6366f1);
+  animation: spin-border 3s linear infinite;
+}
+@property --angle { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
+@keyframes spin-border { to { --angle: 360deg; } }
+
+/* ── Glass surface ───────────────────────────────────── */
+.rn__glass {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  backdrop-filter: blur(16px) saturate(180%);
+  -webkit-backdrop-filter: blur(16px) saturate(180%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ── Mouse-follow shine ──────────────────────────────── */
+.rn__shine {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 1;
+  transition: background 0.05s;
+}
+
+/* ── Content ─────────────────────────────────────────── */
+.rn__content {
+  position: relative;
+  z-index: 2;
+}
+
+.rn__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+/* Badge */
+.rn__badge {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 800;
+  margin-top: 1px;
+}
+.rn__badge--not_started {
+  background: rgba(99,102,241,0.15);
+  border: 1.5px solid rgba(99,102,241,0.4);
+  color: #a5b4fc;
+}
+.rn__badge--in_progress {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border: none;
+  color: #fff;
+  box-shadow: 0 0 12px rgba(99,102,241,0.6);
+}
+.rn__badge--done {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  border: none;
+  color: #fff;
+  box-shadow: 0 0 12px rgba(34,197,94,0.5);
+}
+.rn__check { width: 13px; height: 13px; }
+.rn__num { line-height: 1; }
+
+/* Title */
+.rn__title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #e2e8f0;
+  line-height: 1.4;
+  flex: 1;
+  min-width: 0;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+.rn__title--done {
+  color: #4b7a5e;
+  text-decoration: line-through;
+}
+
+/* Meta tags */
+.rn__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 4px;
+}
+.rn__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 7px;
+  border-radius: 99px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+.rn__tag svg { width: 9px; height: 9px; }
+.rn__tag--course      { background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
+.rn__tag--res         { background: rgba(14,165,233,0.12); color: #7dd3fc; border: 1px solid rgba(14,165,233,0.2); }
+.rn__tag--not_started { background: rgba(99,102,241,0.1);  color: #818cf8; border: 1px solid rgba(99,102,241,0.2); }
+.rn__tag--in_progress { background: rgba(139,92,246,0.15); color: #c4b5fd; border: 1px solid rgba(139,92,246,0.3); }
+.rn__tag--done        { background: rgba(34,197,94,0.12);  color: #86efac; border: 1px solid rgba(34,197,94,0.25); }
+
+/* ── Glow orb (decorative) ───────────────────────────── */
+.rn__orb {
+  position: absolute;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  right: -40px;
+  bottom: -50px;
+  pointer-events: none;
+  z-index: 0;
+  filter: blur(40px);
+  opacity: 0.4;
+}
+.rn__orb--not_started { background: rgba(99,102,241,0.4); }
+.rn__orb--in_progress { background: rgba(139,92,246,0.6); animation: pulse-orb 2s ease-in-out infinite; }
+.rn__orb--done        { background: rgba(34,197,94,0.4); }
+
+@keyframes pulse-orb {
+  0%, 100% { opacity: 0.35; transform: scale(1); }
+  50%       { opacity: 0.6;  transform: scale(1.15); }
+}
+</style>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,10 @@
       "hasInstallScript": true,
       "dependencies": {
         "@nuxt/ui": "^2.22.3",
+        "@vue-flow/background": "^1.3.2",
+        "@vue-flow/controls": "^1.1.3",
+        "@vue-flow/core": "^1.48.2",
+        "@vue-flow/minimap": "^1.5.4",
         "nuxt": "^3.17.0",
         "vue": "^3.5.0",
         "vue-router": "^4.5.0"
@@ -4226,6 +4230,150 @@
       "integrity": "sha512-ynlcBReMgOZj2i6po+qVswtDUeeBRCTgDurjMGShbm8WYZgJ0PA4RmtebBJ0BCYol1qPv3GQF6jK7C9qoVc7lg==",
       "license": "MIT"
     },
+    "node_modules/@vue-flow/background": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/background/-/background-1.3.2.tgz",
+      "integrity": "sha512-eJPhDcLj1wEo45bBoqTXw1uhl0yK2RaQGnEINqvvBsAFKh/camHJd5NPmOdS1w+M9lggc9igUewxaEd3iCQX2w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/controls": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vue-flow/controls/-/controls-1.1.3.tgz",
+      "integrity": "sha512-XCf+G+jCvaWURdFlZmOjifZGw3XMhN5hHlfMGkWh9xot+9nH9gdTZtn+ldIJKtarg3B21iyHU8JjKDhYcB6JMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/core": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.48.2.tgz",
+      "integrity": "sha512-raxhgKWE+G/mcEvXJjGFUDYW9rAI3GOtiHR3ZkNpwBWuIaCC1EYiBmKGwJOoNzVFgwO7COgErnK7i08i287AFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "^10.5.0",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/core": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.1.tgz",
+      "integrity": "sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20",
+        "@vueuse/metadata": "10.11.1",
+        "@vueuse/shared": "10.11.1",
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/metadata": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.1.tgz",
+      "integrity": "sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/shared": {
+      "version": "10.11.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.1.tgz",
+      "integrity": "sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==",
+      "license": "MIT",
+      "dependencies": {
+        "vue-demi": ">=0.14.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vue-flow/core/node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue-flow/minimap": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@vue-flow/minimap/-/minimap-1.5.4.tgz",
+      "integrity": "sha512-l4C+XTAXnRxsRpUdN7cAVFBennC1sVRzq4bDSpVK+ag7tdMczAnhFYGgbLkUw3v3sY6gokyWwMl8CDonp8eB2g==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue-flow/core": "^1.23.0",
+        "vue": "^3.3.0"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
@@ -5793,6 +5941,111 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/db0": {
       "version": "0.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,10 @@
   },
   "dependencies": {
     "@nuxt/ui": "^2.22.3",
+    "@vue-flow/background": "^1.3.2",
+    "@vue-flow/controls": "^1.1.3",
+    "@vue-flow/core": "^1.48.2",
+    "@vue-flow/minimap": "^1.5.4",
     "nuxt": "^3.17.0",
     "vue": "^3.5.0",
     "vue-router": "^4.5.0"

--- a/frontend/pages/my-paths.vue
+++ b/frontend/pages/my-paths.vue
@@ -9,6 +9,24 @@
           Structured roadmaps to guide your IT career in Ireland.
         </p>
       </div>
+      <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+        <button
+          class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
+          :class="view === 'timeline' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+          @click="view = 'timeline'"
+        >
+          <UIcon name="i-heroicons-bars-3-bottom-left" class="h-3.5 w-3.5" />
+          Timeline
+        </button>
+        <button
+          class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
+          :class="view === 'roadmap' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+          @click="view = 'roadmap'"
+        >
+          <UIcon name="i-heroicons-map" class="h-3.5 w-3.5" />
+          Roadmap
+        </button>
+      </div>
     </div>
 
     <!-- Loading -->
@@ -65,8 +83,15 @@
             </div>
           </div>
 
+          <!-- Roadmap view -->
+          <RoadmapFlow
+            v-if="view === 'roadmap' && path.steps.length"
+            :steps="path.steps"
+            @node-click="(step) => toggleExpanded(step.id)"
+          />
+
           <!-- Timeline -->
-          <div v-if="path.steps.length" class="flex flex-col pl-2 sm:pl-6">
+          <div v-if="view === 'timeline' && path.steps.length" class="flex flex-col pl-2 sm:pl-6">
             <div v-for="(step, i) in path.steps" :key="step.id" class="flex gap-4">
 
               <!-- Connector -->
@@ -156,7 +181,7 @@
             </div>
           </div>
 
-          <div v-else class="rounded-xl border border-dashed border-gray-200 px-5 py-8 text-center dark:border-gray-700">
+          <div v-else-if="!path.steps.length" class="rounded-xl border border-dashed border-gray-200 px-5 py-8 text-center dark:border-gray-700">
             <p class="text-sm text-gray-400 dark:text-gray-500">Your consultant hasn't added steps to this path yet.</p>
           </div>
 
@@ -175,6 +200,7 @@ useHead({ title: 'My Learning Paths — CODECV' })
 
 const toast = useToast()
 const { paths, loading, fetchMyPaths, fetchSteps, updateStepProgress } = usePaths()
+const view = ref<'timeline' | 'roadmap'>('timeline')
 
 // local step state per path: pathId → steps with user_status
 const pathSteps = ref<Record<number, PathStep[]>>({})

--- a/frontend/pages/paths/[id].vue
+++ b/frontend/pages/paths/[id].vue
@@ -20,15 +20,40 @@
             </p>
           </div>
         </div>
-        <UButton icon="i-heroicons-plus" size="sm" color="indigo" @click="openAddStep">
-          Add Step
-        </UButton>
+        <div class="flex items-center gap-2">
+          <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+            <button
+              class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
+              :class="view === 'timeline' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+              @click="view = 'timeline'"
+            >
+              <UIcon name="i-heroicons-bars-3-bottom-left" class="h-3.5 w-3.5" /> Timeline
+            </button>
+            <button
+              class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
+              :class="view === 'roadmap' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+              @click="view = 'roadmap'"
+            >
+              <UIcon name="i-heroicons-map" class="h-3.5 w-3.5" /> Roadmap
+            </button>
+          </div>
+          <UButton icon="i-heroicons-plus" size="sm" color="indigo" @click="openAddStep">
+            Add Step
+          </UButton>
+        </div>
       </div>
 
       <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
 
-        <!-- ── Timeline ─────────────────────────────── -->
+        <!-- ── Timeline / Roadmap ─────────────────── -->
         <div class="lg:col-span-2">
+
+          <!-- Roadmap view -->
+          <RoadmapFlow
+            v-if="view === 'roadmap' && steps.length"
+            :steps="steps"
+            @node-click="openEditStep"
+          />
 
           <!-- Empty -->
           <div v-if="!steps.length"
@@ -41,7 +66,7 @@
           </div>
 
           <!-- Steps timeline -->
-          <div v-else class="flex flex-col">
+          <div v-else-if="view === 'timeline'" class="flex flex-col">
             <div v-for="(step, i) in steps" :key="step.id" class="flex gap-4">
 
               <!-- Line + node -->
@@ -220,6 +245,7 @@ const { courses, fetchCourses } = useCourses()
 const currentPath = ref<any>(null)
 const steps       = ref<PathStep[]>([])
 const loading     = ref(true)
+const view        = ref<'timeline' | 'roadmap'>('timeline')
 
 const showModal   = ref(false)
 const saving      = ref(false)


### PR DESCRIPTION
## Summary

- **RoadmapStepNode**: Custom Vue Flow node with mouse-tracking 3D tilt (perspective + rotateX/Y), dynamic shine spotlight, animated conic-gradient rotating border for `in_progress` steps, pulsing glow orb, and entrance animation
- **RoadmapFlow**: Full-canvas dark roadmap (`#060d1a` + radial gradient overlays), purple dot grid, status-coloured glowing edges with `drop-shadow` filters, dark-themed minimap and zoom controls
- **View toggle**: Both `/my-paths` (client) and `/paths/[id]` (admin) now have a Timeline ↔ Roadmap toggle; roadmap view is powered by Vue Flow

## Dependencies added

- `@vue-flow/core`
- `@vue-flow/background`
- `@vue-flow/minimap`
- `@vue-flow/controls`

## Test plan

- [ ] Navigate to `/my-paths` as client — toggle to Roadmap view, verify dark canvas with glowing nodes renders
- [ ] Navigate to `/paths/[id]` as admin — toggle to Roadmap, click a node to open the edit modal
- [ ] Check `in_progress` step shows animated rotating border and pulsing orb
- [ ] Check `done` step shows green tint and strikethrough title
- [ ] Hover a node to verify 3D tilt and shine spotlight effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)