### PR TITLE
feat(Task/CC-13): consultant client management, step progress rules & Udemy-style roadmap

### DIFF
--- a/app/Http/Controllers/Api/PathStepController.php
+++ b/app/Http/Controllers/Api/PathStepController.php
@@ -13,14 +13,11 @@ use Illuminate\Support\Facades\Auth;
 
 class PathStepController extends Controller
 {
-    /**
-     * List steps for a path, annotated with the current user's progress.
-     */
     public function index(Path $path): JsonResponse
     {
-        $steps = $path->steps()->with('course')->get();
+        $steps = $path->steps()->with('course')->orderBy('order')->get();
 
-        $userId = Auth::id();
+        $userId      = Auth::id();
         $progressMap = UserStepProgress::where('user_id', $userId)
             ->whereIn('path_step_id', $steps->pluck('id'))
             ->pluck('status', 'path_step_id');
@@ -33,22 +30,40 @@ class PathStepController extends Controller
         return response()->json(['data' => $data]);
     }
 
-    /**
-     * Create a new step (admin/consultant only — enforced by route middleware).
-     */
+    public function show(PathStep $step): JsonResponse
+    {
+        $step->load('course');
+
+        $userStatus = UserStepProgress::where('user_id', Auth::id())
+            ->where('path_step_id', $step->id)
+            ->value('status') ?? 'not_started';
+
+        return response()->json([
+            'data' => array_merge(
+                (new PathStepResource($step))->resolve(),
+                ['user_status' => $userStatus]
+            ),
+        ]);
+    }
+
     public function store(Request $request, Path $path): JsonResponse
     {
         $validated = $request->validate([
-            'title'       => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'course_id'   => 'nullable|exists:courses,id',
-            'resources'   => 'nullable|array',
-            'resources.*.label' => 'required|string|max:100',
-            'resources.*.url'   => 'required|url|max:500',
-            'order'       => 'nullable|integer|min:0',
+            'title'            => 'required|string|max:255',
+            'description'      => 'nullable|string',
+            'course_id'        => 'nullable|exists:courses,id',
+            'resources'        => 'nullable|array',
+            'resources.*.label'     => 'required|string|max:100',
+            'resources.*.url'       => 'required|url|max:500',
+            'order'            => 'nullable|integer|min:0',
+            'type'             => 'nullable|in:reading,lab,challenge,quiz',
+            'lab_url'          => 'nullable|url|max:1000',
+            'instructions'     => 'nullable|array',
+            'instructions.*.id'   => 'required|integer',
+            'instructions.*.text' => 'required|string|max:500',
+            'challenge_prompt' => 'nullable|string',
         ]);
 
-        // Default order: append at end
         if (! isset($validated['order'])) {
             $validated['order'] = $path->steps()->max('order') + 1;
         }
@@ -62,21 +77,24 @@ class PathStepController extends Controller
         ], 201);
     }
 
-    /**
-     * Update a step.
-     */
     public function update(Request $request, Path $path, PathStep $step): JsonResponse
     {
         abort_if($step->path_id !== $path->id, 404);
 
         $validated = $request->validate([
-            'title'       => 'sometimes|required|string|max:255',
-            'description' => 'nullable|string',
-            'course_id'   => 'nullable|exists:courses,id',
-            'resources'   => 'nullable|array',
-            'resources.*.label' => 'required|string|max:100',
-            'resources.*.url'   => 'required|url|max:500',
-            'order'       => 'nullable|integer|min:0',
+            'title'            => 'sometimes|required|string|max:255',
+            'description'      => 'nullable|string',
+            'course_id'        => 'nullable|exists:courses,id',
+            'resources'        => 'nullable|array',
+            'resources.*.label'     => 'required|string|max:100',
+            'resources.*.url'       => 'required|url|max:500',
+            'order'            => 'nullable|integer|min:0',
+            'type'             => 'nullable|in:reading,lab,challenge,quiz',
+            'lab_url'          => 'nullable|url|max:1000',
+            'instructions'     => 'nullable|array',
+            'instructions.*.id'   => 'required|integer',
+            'instructions.*.text' => 'required|string|max:500',
+            'challenge_prompt' => 'nullable|string',
         ]);
 
         $step->update($validated);
@@ -88,9 +106,6 @@ class PathStepController extends Controller
         ]);
     }
 
-    /**
-     * Delete a step.
-     */
     public function destroy(Path $path, PathStep $step): JsonResponse
     {
         abort_if($step->path_id !== $path->id, 404);
@@ -99,9 +114,6 @@ class PathStepController extends Controller
         return response()->json(['message' => 'Step deleted']);
     }
 
-    /**
-     * Reorder steps by passing an ordered array of step IDs.
-     */
     public function reorder(Request $request, Path $path): JsonResponse
     {
         $request->validate([
@@ -116,17 +128,44 @@ class PathStepController extends Controller
         return response()->json(['message' => 'Steps reordered']);
     }
 
-    /**
-     * Update the authenticated user's progress on a step.
-     */
     public function updateProgress(Request $request, PathStep $step): JsonResponse
     {
         $request->validate([
             'status' => 'required|in:not_started,in_progress,done',
         ]);
 
+        $userId = Auth::id();
+
+        if ($request->status === 'in_progress') {
+            $precedingIds = PathStep::where('path_id', $step->path_id)
+                ->where('order', '<', $step->order)
+                ->pluck('id');
+
+            $blocker = UserStepProgress::where('user_id', $userId)
+                ->whereIn('path_step_id', $precedingIds)
+                ->where('status', 'in_progress')
+                ->with('step')
+                ->first();
+
+            if ($blocker) {
+                return response()->json([
+                    'message'       => 'Complete the current step first.',
+                    'blocking_step' => $blocker->step?->title,
+                ], 422);
+            }
+
+            $siblingIds = PathStep::where('path_id', $step->path_id)
+                ->where('id', '!=', $step->id)
+                ->pluck('id');
+
+            UserStepProgress::where('user_id', $userId)
+                ->whereIn('path_step_id', $siblingIds)
+                ->where('status', 'in_progress')
+                ->update(['status' => 'not_started']);
+        }
+
         UserStepProgress::updateOrCreate(
-            ['user_id' => Auth::id(), 'path_step_id' => $step->id],
+            ['user_id' => $userId, 'path_step_id' => $step->id],
             ['status' => $request->status]
         );
 

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -6,8 +6,11 @@ use App\Exceptions\AuthorizationException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\UserRequest;
 use App\Http\Resources\UserResource;
+use App\Models\Path;
 use App\Models\User;
+use App\Models\UserStepProgress;
 use App\Notifications\NewClientOnboarded;
+use App\Services\PlanService;
 use App\Services\UserService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,7 +20,8 @@ use Illuminate\Support\Facades\Auth;
 class UserController extends Controller
 {
     public function __construct(
-        private readonly UserService $userService
+        private readonly UserService $userService,
+        private readonly PlanService $planService,
     ) {}
 
     public function index(Request $request): AnonymousResourceCollection
@@ -164,6 +168,115 @@ class UserController extends Controller
             'message' => 'Consultant assigned successfully.',
             'user'    => new UserResource($user),
         ]);
+    }
+
+    public function myClients(): JsonResponse
+    {
+        $consultant = Auth::user();
+
+        $clients = User::where('consultant_id', $consultant->id)
+            ->with(['profile', 'roles'])
+            ->get()
+            ->map(function (User $client) {
+                $paths = Path::whereHas('plans', function ($q) use ($client) {
+                    $q->whereHas('clients', fn ($q2) => $q2->where('users.id', $client->id));
+                })->withCount('steps')->get();
+
+                $stepIds    = $paths->flatMap(fn ($p) => $p->steps()->pluck('id'));
+                $doneCount  = UserStepProgress::where('user_id', $client->id)
+                    ->whereIn('path_step_id', $stepIds)
+                    ->where('status', 'done')
+                    ->count();
+                $totalSteps = $stepIds->count();
+
+                return [
+                    'id'           => $client->id,
+                    'fullname'     => $client->fullname,
+                    'email'        => $client->email,
+                    'profile'      => $client->profile ? [
+                        'profession'       => $client->profile->profession,
+                        'level'            => $client->profile->level,
+                        'profile_image_url'=> $client->profile->profile_image
+                            ? asset('storage/'.$client->profile->profile_image)
+                            : null,
+                    ] : null,
+                    'path_count'   => $paths->count(),
+                    'progress_pct' => $totalSteps > 0 ? (int) round($doneCount / $totalSteps * 100) : 0,
+                    'done_steps'   => $doneCount,
+                    'total_steps'  => $totalSteps,
+                ];
+            });
+
+        return response()->json(['data' => $clients]);
+    }
+
+    public function clientDetail(User $client): JsonResponse
+    {
+        $consultant = Auth::user();
+
+        if ($client->consultant_id !== $consultant->id && ! $consultant->hasRole('admin')) {
+            return response()->json(['message' => 'Unauthorized.'], 403);
+        }
+
+        $client->load(['profile', 'roles']);
+
+        $paths = Path::whereHas('plans', function ($q) use ($client) {
+            $q->whereHas('clients', fn ($q2) => $q2->where('users.id', $client->id));
+        })->with(['steps.course'])->get();
+
+        $stepIds     = $paths->flatMap(fn ($p) => $p->steps->pluck('id'));
+        $progressMap = UserStepProgress::where('user_id', $client->id)
+            ->whereIn('path_step_id', $stepIds)
+            ->pluck('status', 'path_step_id');
+
+        $pathData = $paths->map(fn ($path) => [
+            'id'          => $path->id,
+            'name'        => $path->name,
+            'description' => $path->description,
+            'steps'       => $path->steps->map(fn ($step) => [
+                'id'          => $step->id,
+                'order'       => $step->order,
+                'title'       => $step->title,
+                'type'        => $step->type,
+                'course'      => $step->course ? ['id' => $step->course->id, 'name' => $step->course->name] : null,
+                'user_status' => $progressMap->get($step->id, 'not_started'),
+            ])->sortBy('order')->values(),
+            'done_count'  => $path->steps->filter(fn ($s) => $progressMap->get($s->id) === 'done')->count(),
+            'total_count' => $path->steps->count(),
+        ]);
+
+        return response()->json([
+            'user'  => new UserResource($client),
+            'paths' => $pathData->values(),
+        ]);
+    }
+
+    public function assignPath(Request $request, User $client): JsonResponse
+    {
+        $consultant = Auth::user();
+
+        if ($client->consultant_id !== $consultant->id && ! $consultant->hasRole('admin')) {
+            return response()->json(['message' => 'Unauthorized.'], 403);
+        }
+
+        $request->validate(['path_id' => 'required|exists:paths,id']);
+
+        $this->planService->assignPathToClient($consultant->id, $client->id, $request->path_id);
+
+        return response()->json(['message' => 'Path assigned successfully.']);
+    }
+
+    public function removePath(User $client, Path $path): JsonResponse
+    {
+        $consultant = Auth::user();
+
+        if ($client->consultant_id !== $consultant->id && ! $consultant->hasRole('admin')) {
+            return response()->json(['message' => 'Unauthorized.'], 403);
+        }
+
+        $this->planService->removePathFromClient($consultant->id, $client->id, $path->id);
+
+        return response()->json(['message' => 'Path removed successfully.']);
     }
 
     public function completeOnboarding(Request $request): JsonResponse

--- a/app/Http/Resources/PathStepResource.php
+++ b/app/Http/Resources/PathStepResource.php
@@ -10,19 +10,23 @@ class PathStepResource extends JsonResource
     public function toArray(Request $request): array
     {
         return [
-            'id'          => $this->id,
-            'path_id'     => $this->path_id,
-            'title'       => $this->title,
-            'description' => $this->description,
-            'resources'   => $this->resources ?? [],
-            'order'       => $this->order,
-            'course'      => $this->when($this->relationLoaded('course') && $this->course, fn () => [
+            'id'               => $this->id,
+            'path_id'          => $this->path_id,
+            'title'            => $this->title,
+            'description'      => $this->description,
+            'type'             => $this->type ?? 'reading',
+            'lab_url'          => $this->lab_url,
+            'instructions'     => $this->instructions ?? [],
+            'challenge_prompt' => $this->challenge_prompt,
+            'resources'        => $this->resources ?? [],
+            'order'            => $this->order,
+            'course'           => $this->when($this->relationLoaded('course') && $this->course, fn () => [
                 'id'   => $this->course->id,
                 'name' => $this->course->name,
                 'slug' => $this->course->slug,
             ]),
-            'created_at'  => $this->created_at,
-            'updated_at'  => $this->updated_at,
+            'created_at'       => $this->created_at,
+            'updated_at'       => $this->updated_at,
         ];
     }
 }

--- a/app/Models/PathStep.php
+++ b/app/Models/PathStep.php
@@ -17,11 +17,16 @@ class PathStep extends Model
         'description',
         'resources',
         'order',
+        'type',
+        'lab_url',
+        'instructions',
+        'challenge_prompt',
     ];
 
     protected $casts = [
-        'resources' => 'array',
-        'order' => 'integer',
+        'resources'    => 'array',
+        'instructions' => 'array',
+        'order'        => 'integer',
     ];
 
     public function path(): BelongsTo

--- a/app/Services/PlanService.php
+++ b/app/Services/PlanService.php
@@ -82,4 +82,37 @@ class PlanService
     {
         $plan->clients()->detach($clientId);
     }
+
+    public function findOrCreateForClient(int $consultantId, int $clientId): Plan
+    {
+        $plan = Plan::where('consultant_id', $consultantId)
+            ->whereHas('clients', fn ($q) => $q->where('users.id', $clientId))
+            ->first();
+
+        if (! $plan) {
+            $client = \App\Models\User::findOrFail($clientId);
+            $plan = Plan::create([
+                'name'          => "{$client->fullname}'s Training Plan",
+                'consultant_id' => $consultantId,
+            ]);
+            $plan->clients()->attach($clientId);
+        }
+
+        return $plan;
+    }
+
+    public function assignPathToClient(int $consultantId, int $clientId, int $pathId): void
+    {
+        $plan = $this->findOrCreateForClient($consultantId, $clientId);
+        $plan->paths()->syncWithoutDetaching([$pathId]);
+    }
+
+    public function removePathFromClient(int $consultantId, int $clientId, int $pathId): void
+    {
+        $plan = Plan::where('consultant_id', $consultantId)
+            ->whereHas('clients', fn ($q) => $q->where('users.id', $clientId))
+            ->first();
+
+        $plan?->paths()->detach($pathId);
+    }
 }

--- a/database/factories/PathStepFactory.php
+++ b/database/factories/PathStepFactory.php
@@ -10,15 +10,154 @@ class PathStepFactory extends Factory
 {
     protected $model = PathStep::class;
 
+    private static array $steps = [
+        [
+            'title'       => 'PHP & OOP Foundations',
+            'type'        => 'reading',
+            'description' => 'Master the building blocks of server-side PHP development with a strong focus on Object-Oriented Programming. You will learn how PHP executes on the server, how to structure code using classes and interfaces, and why encapsulation and inheritance lead to more maintainable applications. This step sets the foundation for every Laravel concept you will encounter later.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Understand PHP\'s request lifecycle and how it differs from client-side scripting'],
+                ['id' => 2, 'text' => 'Define classes, properties, and methods using visibility modifiers'],
+                ['id' => 3, 'text' => 'Apply inheritance and interfaces to model real-world relationships'],
+                ['id' => 4, 'text' => 'Use namespaces and PSR-4 autoloading with Composer'],
+                ['id' => 5, 'text' => 'Write clean, type-hinted PHP 8.x code with union types and match expressions'],
+            ],
+            'resources' => [
+                ['label' => 'PHP Manual — OOP', 'url' => 'https://www.php.net/manual/en/language.oop5.php'],
+                ['label' => 'PHP 8 What\'s New', 'url' => 'https://stitcher.io/blog/new-in-php-8'],
+            ],
+        ],
+        [
+            'title'       => 'Laravel Essentials',
+            'type'        => 'reading',
+            'description' => 'Get hands-on with the most popular PHP framework in the industry. Laravel abstracts common web development tasks — routing, database access, authentication, and validation — so you can focus on business logic. By the end of this step you will be able to scaffold a working web application from scratch using Artisan, Eloquent, and Blade.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Set up a new Laravel project and understand the directory structure'],
+                ['id' => 2, 'text' => 'Define routes, controllers, and return JSON or Blade responses'],
+                ['id' => 3, 'text' => 'Use Eloquent models to perform CRUD operations without raw SQL'],
+                ['id' => 4, 'text' => 'Validate incoming requests using Form Request classes'],
+                ['id' => 5, 'text' => 'Run database migrations and seeders to manage schema changes'],
+            ],
+            'resources' => [
+                ['label' => 'Laravel Docs', 'url' => 'https://laravel.com/docs'],
+                ['label' => 'Laracasts — Laravel From Scratch', 'url' => 'https://laracasts.com/series/laravel-8-from-scratch'],
+            ],
+        ],
+        [
+            'title'       => 'MySQL & Database Design',
+            'type'        => 'reading',
+            'description' => 'A well-designed database is the backbone of every production application. This step covers the relational model in depth — from normalisation and schema design to indexing strategies and query optimisation. You will learn how to think like a DBA and write efficient queries that scale as your data grows.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Design normalised schemas up to 3NF and know when to denormalise'],
+                ['id' => 2, 'text' => 'Write complex JOINs, subqueries, and aggregate functions'],
+                ['id' => 3, 'text' => 'Create and choose the right indexes (B-Tree, composite, covering)'],
+                ['id' => 4, 'text' => 'Use EXPLAIN to analyse query execution plans'],
+                ['id' => 5, 'text' => 'Understand transactions, ACID guarantees, and locking behaviour'],
+            ],
+            'resources' => [
+                ['label' => 'Use The Index, Luke', 'url' => 'https://use-the-index-luke.com'],
+                ['label' => 'MySQL 8 Reference Manual', 'url' => 'https://dev.mysql.com/doc/refman/8.0/en/'],
+            ],
+        ],
+        [
+            'title'       => 'RESTful API Development',
+            'type'        => 'lab',
+            'description' => 'REST is the dominant architectural style for APIs consumed by mobile apps, SPAs, and third-party integrations. In this lab you will build a fully functional REST API with Laravel, covering resource routing, API Resources for response shaping, token-based authentication with Sanctum, and proper HTTP status codes. You will leave with a production-ready API skeleton.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Implement CRUD endpoints following REST conventions (GET, POST, PUT, DELETE)'],
+                ['id' => 2, 'text' => 'Transform model data with Laravel API Resources and Resource Collections'],
+                ['id' => 3, 'text' => 'Secure endpoints with Laravel Sanctum token authentication'],
+                ['id' => 4, 'text' => 'Handle validation errors and return RFC 7807 problem responses'],
+                ['id' => 5, 'text' => 'Write feature tests using Laravel\'s HTTP testing helpers'],
+            ],
+            'challenge_prompt' => 'Build a fully authenticated REST API for a Task Manager: users can register, log in, and manage their own tasks (create, list, update, delete). Protect all task routes with Sanctum. Include at least one test per endpoint.',
+            'resources' => [
+                ['label' => 'Laravel API Resources', 'url' => 'https://laravel.com/docs/eloquent-resources'],
+                ['label' => 'REST API Design Best Practices', 'url' => 'https://restfulapi.net'],
+            ],
+        ],
+        [
+            'title'       => 'Git & Version Control',
+            'type'        => 'reading',
+            'description' => 'Version control is a non-negotiable skill for every professional developer. This step goes beyond basic commits to cover the branching strategies and collaboration workflows used by engineering teams at scale — including Git Flow, trunk-based development, and pull request best practices. You will also learn how to recover from common mistakes confidently.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Understand the Git object model: blobs, trees, commits, and refs'],
+                ['id' => 2, 'text' => 'Branch, merge, and rebase with a clear mental model of what each does'],
+                ['id' => 3, 'text' => 'Write atomic, conventional commits and meaningful PR descriptions'],
+                ['id' => 4, 'text' => 'Resolve merge conflicts and use git bisect to find regressions'],
+                ['id' => 5, 'text' => 'Apply Git Flow or trunk-based development in a team context'],
+            ],
+            'resources' => [
+                ['label' => 'Pro Git Book (free)', 'url' => 'https://git-scm.com/book/en/v2'],
+                ['label' => 'Conventional Commits', 'url' => 'https://www.conventionalcommits.org'],
+            ],
+        ],
+        [
+            'title'       => 'Docker & Local Dev Environment',
+            'type'        => 'lab',
+            'description' => 'Containers have revolutionised how software is developed, shipped, and run. This lab walks you through containerising a Laravel + MySQL + Nginx stack with Docker Compose, mirroring how production environments are configured. You will understand image layering, volume mounts, networking, and how to keep your development environment reproducible across any machine.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Write a Dockerfile for a PHP-FPM Laravel application'],
+                ['id' => 2, 'text' => 'Compose multi-service environments (app, db, redis, nginx) with Docker Compose'],
+                ['id' => 3, 'text' => 'Manage persistent data with named volumes and bind mounts'],
+                ['id' => 4, 'text' => 'Configure service networking and environment variable injection'],
+                ['id' => 5, 'text' => 'Use multi-stage builds to create lean production images'],
+            ],
+            'resources' => [
+                ['label' => 'Docker Official Docs', 'url' => 'https://docs.docker.com'],
+                ['label' => 'Docker Compose Docs', 'url' => 'https://docs.docker.com/compose/'],
+            ],
+        ],
+        [
+            'title'       => 'AWS Basics for Developers',
+            'type'        => 'reading',
+            'description' => 'Cloud infrastructure is a core competency for backend engineers working in Ireland\'s tech sector. This step introduces the AWS services you will encounter most often on the job: EC2, S3, RDS, and IAM. You will understand the shared responsibility model, how to deploy a basic application, and how to manage permissions securely — essential knowledge for any technical interview.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Navigate the AWS console and understand regions, AZs, and VPCs'],
+                ['id' => 2, 'text' => 'Launch and connect to an EC2 instance; understand security groups'],
+                ['id' => 3, 'text' => 'Store and retrieve objects from S3 with appropriate bucket policies'],
+                ['id' => 4, 'text' => 'Provision a managed RDS instance and connect from your application'],
+                ['id' => 5, 'text' => 'Create IAM users, roles, and policies following least-privilege principles'],
+            ],
+            'resources' => [
+                ['label' => 'AWS Free Tier', 'url' => 'https://aws.amazon.com/free/'],
+                ['label' => 'AWS Well-Architected Framework', 'url' => 'https://aws.amazon.com/architecture/well-architected/'],
+            ],
+        ],
+        [
+            'title'       => 'CV & LinkedIn Optimisation',
+            'type'        => 'challenge',
+            'description' => 'Your CV and LinkedIn profile are your professional shop window in the Irish and EU tech job market. Recruiters spend an average of 7 seconds scanning a CV — this step teaches you how to pass the ATS filter, tell a compelling career story, and position yourself for the roles you actually want. You will also learn how to leverage LinkedIn\'s algorithm to get inbound interest from recruiters.',
+            'instructions' => [
+                ['id' => 1, 'text' => 'Structure your CV for ATS compatibility (clean formatting, keyword alignment)'],
+                ['id' => 2, 'text' => 'Write achievement-oriented bullet points using the CAR framework (Context, Action, Result)'],
+                ['id' => 3, 'text' => 'Optimise your LinkedIn headline, About section, and skills for search visibility'],
+                ['id' => 4, 'text' => 'Build a consistent personal brand across GitHub, LinkedIn, and your CV'],
+                ['id' => 5, 'text' => 'Tailor your CV for each job application without starting from scratch'],
+            ],
+            'challenge_prompt' => 'Rewrite your CV using the CAR framework for every bullet point. Then update your LinkedIn About section to include your target role, your top 3 technical skills, and one concrete project outcome. Share both with your consultant for feedback.',
+            'resources' => [
+                ['label' => 'Tech CV Template', 'url' => 'https://www.overleaf.com/gallery/tagged/cv'],
+                ['label' => 'LinkedIn Profile Checklist', 'url' => 'https://business.linkedin.com/talent-solutions/resources/talent-acquisition/linkedin-profile-completeness'],
+            ],
+        ],
+    ];
+
     public function definition(): array
     {
+        $step  = fake()->randomElement(self::$steps);
+        $order = fake()->numberBetween(0, 20);
+
         return [
-            'path_id'     => Path::factory(),
-            'title'       => fake()->sentence(4),
-            'description' => fake()->paragraph(),
-            'order'       => fake()->numberBetween(0, 100),
-            'resources'   => null,
-            'course_id'   => null,
+            'path_id'          => Path::factory(),
+            'title'            => $step['title'],
+            'description'      => $step['description'],
+            'type'             => $step['type'],
+            'order'            => $order,
+            'instructions'     => $step['instructions'] ?? null,
+            'challenge_prompt' => $step['challenge_prompt'] ?? null,
+            'resources'        => $step['resources'] ?? null,
+            'course_id'        => null,
         ];
     }
 }

--- a/database/migrations/2026_04_19_235239_add_lab_fields_to_path_steps_table.php
+++ b/database/migrations/2026_04_19_235239_add_lab_fields_to_path_steps_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('path_steps', function (Blueprint $table) {
+            $table->enum('type', ['reading', 'lab', 'challenge', 'quiz'])->default('reading')->after('order');
+            $table->string('lab_url')->nullable()->after('type');
+            $table->json('instructions')->nullable()->after('lab_url'); // [{ id, text }]
+            $table->text('challenge_prompt')->nullable()->after('instructions');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('path_steps', function (Blueprint $table) {
+            $table->dropColumn(['type', 'lab_url', 'instructions', 'challenge_prompt']);
+        });
+    }
+};

--- a/frontend/components/RoadmapFlow.vue
+++ b/frontend/components/RoadmapFlow.vue
@@ -1,35 +1,36 @@
 <template>
   <ClientOnly>
-    <div class="rf-wrap" :style="{ height: wrapHeight }">
+    <div
+      class="rf-wrap"
+      :class="isDark ? 'rf-wrap--dark' : 'rf-wrap--light'"
+      :style="{ height: wrapHeight }"
+    >
       <VueFlow
         :nodes="nodes"
         :edges="edges"
         :node-types="nodeTypes"
         fit-view-on-init
-        :min-zoom="0.3"
-        :max-zoom="1.8"
+        :fit-view-on-init-options="{ padding: 0.12 }"
+        :min-zoom="0.25"
+        :max-zoom="2"
         :nodes-draggable="false"
         :nodes-connectable="false"
         :elements-selectable="false"
         class="rf-flow"
         @node-click="onNodeClick"
       >
-        <!-- Dark dot grid -->
         <Background
           variant="dots"
           :gap="28"
           :size="1.2"
-          pattern-color="rgba(99,102,241,0.2)"
+          :pattern-color="isDark ? 'rgba(0,172,105,0.18)' : 'rgba(0,172,105,0.1)'"
         />
-
-        <!-- Minimap for long paths -->
         <MiniMap
-          v-if="steps.length > 5"
+          v-if="steps.length > 6"
           :node-color="minimapColor"
-          :mask-color="'rgba(0,0,0,0.6)'"
+          :mask-color="isDark ? 'rgba(0,0,0,0.55)' : 'rgba(255,255,255,0.6)'"
           class="rf-minimap"
         />
-
         <Controls :show-interactive="false" class="rf-controls" />
       </VueFlow>
     </div>
@@ -41,7 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import { VueFlow } from '@vue-flow/core'
+import { VueFlow, Position } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { MiniMap } from '@vue-flow/minimap'
 import { Controls } from '@vue-flow/controls'
@@ -63,25 +64,36 @@ interface Step {
 const props = defineProps<{ steps: Step[] }>()
 const emit  = defineEmits<{ (e: 'nodeClick', step: Step): void }>()
 
+const colorMode = useColorMode()
+const isDark    = computed(() => colorMode.value === 'dark')
 const nodeTypes = { step: markRaw(RoadmapStepNode) }
 
-const NODE_H = 100
-const GAP    = 52
+// Snake layout constants
+const NODE_W = 240, NODE_H = 90, V_GAP = 60, H_GAP = 100
+const SRC = [Position.Right,  Position.Bottom, Position.Left,  Position.Bottom]
+const TGT = [Position.Top,    Position.Left,   Position.Top,   Position.Right]
 
 const nodes = computed(() =>
-  props.steps.map((step, i) => ({
-    id:       String(step.id),
-    type:     'step',
-    position: { x: 0, y: i * (NODE_H + GAP) },
-    data: {
-      order:         step.order ?? i + 1,
-      title:         step.title,
-      course:        step.course?.name ?? null,
-      resourceCount: (step.resources ?? []).length,
-      status:        step.user_status,
-      step,
-    },
-  }))
+  props.steps.map((step, i) => {
+    const row = Math.floor(i / 2)
+    const col = (row % 2 === 0) ? (i % 2) : (1 - (i % 2))
+    return {
+      id:             String(step.id),
+      type:           'step',
+      position:       { x: col * (NODE_W + H_GAP), y: row * (NODE_H + V_GAP) },
+      sourcePosition: SRC[i % 4],
+      targetPosition: TGT[i % 4],
+      data: {
+        order:         step.order ?? i + 1,
+        index:         i,
+        title:         step.title,
+        course:        step.course?.name ?? null,
+        resourceCount: (step.resources ?? []).length,
+        status:        step.user_status,
+        step,
+      },
+    }
+  })
 )
 
 const edges = computed(() =>
@@ -89,37 +101,29 @@ const edges = computed(() =>
     const next   = props.steps[i + 1]
     const isDone = step.user_status === 'done'
     const isWip  = step.user_status === 'in_progress'
+    const stroke = isDone ? '#00AC69' : isWip ? '#00d97e' : 'rgba(0,172,105,0.3)'
     return {
       id:        `e${step.id}-${next.id}`,
       source:    String(step.id),
       target:    String(next.id),
       animated:  isWip,
       type:      'smoothstep',
-      style: {
-        stroke:      isDone ? '#22c55e' : isWip ? '#818cf8' : 'rgba(99,102,241,0.35)',
-        strokeWidth: isDone || isWip ? 2.5 : 1.5,
-        filter:      isDone ? 'drop-shadow(0 0 4px #22c55e)' : isWip ? 'drop-shadow(0 0 6px #818cf8)' : 'none',
-      },
-      markerEnd: {
-        type:   'arrowclosed',
-        color:  isDone ? '#22c55e' : isWip ? '#818cf8' : 'rgba(99,102,241,0.4)',
-        width:  12,
-        height: 12,
-      },
+      style:     { stroke, strokeWidth: isDone || isWip ? 2 : 1.5 },
+      markerEnd: { type: 'arrowclosed', color: stroke, width: 11, height: 11 },
     }
   })
 )
 
 const wrapHeight = computed(() => {
-  const h = props.steps.length * (NODE_H + GAP) + 120
-  return `${Math.max(h, 340)}px`
+  const rows = Math.ceil(props.steps.length / 2)
+  return `${Math.max(rows * (NODE_H + V_GAP) + 120, 300)}px`
 })
 
 function minimapColor(node: any) {
   const s = node.data?.status
-  if (s === 'done')        return '#22c55e'
-  if (s === 'in_progress') return '#6366f1'
-  return '#334155'
+  if (s === 'done')        return '#00AC69'
+  if (s === 'in_progress') return '#00d97e'
+  return isDark.value ? '#1D252C' : '#b2dfce'
 }
 
 function onNodeClick({ node }: any) {
@@ -128,53 +132,39 @@ function onNodeClick({ node }: any) {
 </script>
 
 <style>
-/* ── Canvas ──────────────────────────────────────────── */
-.rf-wrap {
-  width: 100%;
-  border-radius: 16px;
-  overflow: hidden;
-  border: 1px solid rgba(99,102,241,0.2);
+.rf-wrap { width: 100%; border-radius: 12px; overflow: hidden; }
+
+.rf-wrap--dark {
+  border: 1px solid rgba(0,172,105,0.2);
   background:
-    radial-gradient(ellipse at 20% 10%,  rgba(99,102,241,0.12) 0%, transparent 45%),
-    radial-gradient(ellipse at 80% 80%,  rgba(6,182,212,0.08)  0%, transparent 45%),
-    radial-gradient(ellipse at 60% 40%,  rgba(139,92,246,0.07) 0%, transparent 40%),
-    #060d1a;
+    radial-gradient(ellipse at 20% 15%, rgba(0,172,105,0.07) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 80%, rgba(0,125,74,0.05)  0%, transparent 50%),
+    #1D252C;
+}
+.rf-wrap--light {
+  border: 1px solid #b2dfce;
+  background: #f0faf5;
 }
 
 .rf-flow { width: 100%; height: 100%; }
-
-/* Override VueFlow internals to fit dark theme */
 .rf-flow .vue-flow__background { background: transparent !important; }
-.rf-flow .vue-flow__pane       { cursor: grab; }
-.rf-flow .vue-flow__pane:active { cursor: grabbing; }
+.rf-flow .vue-flow__pane       { cursor: default; }
 
 /* Minimap */
-.rf-minimap {
-  border-radius: 10px !important;
-  overflow: hidden;
-  border: 1px solid rgba(99,102,241,0.25) !important;
-  background: rgba(6,13,26,0.9) !important;
-}
+.rf-minimap { border-radius: 8px !important; overflow: hidden; }
+.rf-wrap--dark  .rf-minimap { border: 1px solid rgba(0,172,105,0.2) !important; background: rgba(29,37,44,0.95) !important; }
+.rf-wrap--light .rf-minimap { border: 1px solid #b2dfce !important; background: rgba(240,250,245,0.95) !important; }
 
 /* Controls */
-.rf-controls {
-  border-radius: 10px !important;
-  overflow: hidden;
-  border: 1px solid rgba(99,102,241,0.25) !important;
-  background: rgba(15,23,42,0.9) !important;
-  box-shadow: none !important;
-}
-.rf-controls button {
-  background: transparent !important;
-  border-bottom: 1px solid rgba(99,102,241,0.15) !important;
-  color: #94a3b8 !important;
-}
-.rf-controls button:hover { background: rgba(99,102,241,0.15) !important; color: #a5b4fc !important; }
+.rf-controls { border-radius: 8px !important; overflow: hidden; box-shadow: none !important; }
+.rf-wrap--dark  .rf-controls { border: 1px solid rgba(0,172,105,0.2) !important; background: #1a2220 !important; }
+.rf-wrap--light .rf-controls { border: 1px solid #b2dfce !important; background: #ffffff !important; }
+
+.rf-wrap--dark  .rf-controls button { background: transparent !important; border-bottom: 1px solid rgba(0,172,105,0.15) !important; color: #5dd9a4 !important; }
+.rf-wrap--dark  .rf-controls button:hover { background: rgba(0,172,105,0.12) !important; color: #00AC69 !important; }
+.rf-wrap--light .rf-controls button { background: transparent !important; border-bottom: 1px solid #b2dfce !important; color: #007D4A !important; }
+.rf-wrap--light .rf-controls button:hover { background: #e0f5ec !important; color: #005c34 !important; }
 .rf-controls button:last-child { border-bottom: none !important; }
 
-/* Fallback */
-.rf-fallback {
-  display: flex; align-items: center; justify-content: center;
-  height: 240px; font-size: 0.875rem; color: #64748b;
-}
+.rf-fallback { display: flex; align-items: center; justify-content: center; height: 240px; font-size: 0.875rem; color: #6b7280; }
 </style>

--- a/frontend/components/RoadmapStepNode.vue
+++ b/frontend/components/RoadmapStepNode.vue
@@ -1,24 +1,15 @@
 <template>
   <div
     class="rn"
-    :class="[`rn--${status}`, entered && 'rn--entered']"
-    @mouseenter="onEnter"
+    :class="[`rn--${status}`, isDark ? 'rn--dark' : 'rn--light']"
+    :style="nodeStyle"
     @mouseleave="onLeave"
     @mousemove="onMove"
-    :style="tiltStyle"
   >
-    <!-- Animated gradient border for in_progress -->
     <div v-if="status === 'in_progress'" class="rn__border-anim" />
-
-    <!-- Glass surface -->
-    <div class="rn__glass" />
-
-    <!-- Inner shine highlight -->
     <div class="rn__shine" :style="shineStyle" />
 
-    <!-- Content -->
     <div class="rn__content">
-      <!-- Badge + title row -->
       <div class="rn__header">
         <div class="rn__badge" :class="`rn__badge--${status}`">
           <svg v-if="status === 'done'" viewBox="0 0 14 14" fill="none" class="rn__check">
@@ -29,13 +20,11 @@
           </svg>
           <span v-else class="rn__num">{{ data.order }}</span>
         </div>
-
         <p class="rn__title" :class="status === 'done' && 'rn__title--done'">
           {{ data.title }}
         </p>
       </div>
 
-      <!-- Meta row -->
       <div class="rn__meta">
         <span v-if="data.course" class="rn__tag rn__tag--course">
           <svg viewBox="0 0 12 12" fill="none"><path d="M1 3l5 2.5L11 3M1 3v6l5 2.5M1 3l5-2.5L11 3v6L6 11.5" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/></svg>
@@ -49,11 +38,8 @@
       </div>
     </div>
 
-    <!-- Glow orb -->
-    <div class="rn__orb" :class="`rn__orb--${status}`" />
-
-    <Handle type="target" :position="Position.Top"    style="opacity:0;pointer-events:none;background:transparent;border:none" />
-    <Handle type="source" :position="Position.Bottom" style="opacity:0;pointer-events:none;background:transparent;border:none" />
+    <Handle type="target" :position="(props.targetPosition as Position) ?? Position.Top"    style="opacity:0;pointer-events:none;background:transparent;border:none" />
+    <Handle type="source" :position="(props.sourcePosition as Position) ?? Position.Bottom" style="opacity:0;pointer-events:none;background:transparent;border:none" />
   </div>
 </template>
 
@@ -63,246 +49,171 @@ import { Handle, Position } from '@vue-flow/core'
 const props = defineProps<{
   data: {
     order: number
+    index: number
     title: string
     course?: string | null
     resourceCount?: number
     status?: 'not_started' | 'in_progress' | 'done'
     step: any
   }
+  sourcePosition?: string
+  targetPosition?: string
 }>()
 
 defineEmits(['click'])
 
-const status = computed(() => props.data.status ?? 'not_started')
+const colorMode = useColorMode()
+const isDark    = computed(() => colorMode.value === 'dark')
+const status    = computed(() => props.data.status ?? 'not_started')
+const statusLabel = computed(() => ({ done: 'Done', in_progress: 'In Progress', not_started: 'Not Started' }[status.value]))
 
-const statusLabel = computed(() => ({
-  done:        'Done',
-  in_progress: 'In Progress',
-  not_started: 'Not Started',
-}[status.value]))
+const tiltX = ref(0), tiltY = ref(0), shineX = ref(50), shineY = ref(50)
+let raf = 0
 
-// ── 3D tilt ──────────────────────────────────────────────
-const tiltX    = ref(0)
-const tiltY    = ref(0)
-const shineX   = ref(50)
-const shineY   = ref(50)
-const entered  = ref(false)
-let   raf      = 0
-
-function onEnter() { entered.value = true }
 function onLeave() {
   cancelAnimationFrame(raf)
-  raf = requestAnimationFrame(() => {
-    tiltX.value  = 0
-    tiltY.value  = 0
-    shineX.value = 50
-    shineY.value = 50
-  })
+  raf = requestAnimationFrame(() => { tiltX.value = 0; tiltY.value = 0; shineX.value = 50; shineY.value = 50 })
 }
-
 function onMove(e: MouseEvent) {
-  const el   = e.currentTarget as HTMLElement
-  const rect = el.getBoundingClientRect()
-  const x    = (e.clientX - rect.left) / rect.width   // 0-1
-  const y    = (e.clientY - rect.top)  / rect.height  // 0-1
+  const r = (e.currentTarget as HTMLElement).getBoundingClientRect()
+  const x = (e.clientX - r.left) / r.width
+  const y = (e.clientY - r.top) / r.height
   raf = requestAnimationFrame(() => {
-    tiltY.value  =  (x - 0.5) * 16
-    tiltX.value  = -(y - 0.5) * 10
-    shineX.value = x * 100
-    shineY.value = y * 100
+    tiltY.value = (x - 0.5) * 12; tiltX.value = -(y - 0.5) * 8
+    shineX.value = x * 100; shineY.value = y * 100
   })
 }
 
-const tiltStyle = computed(() => ({
+const nodeStyle = computed(() => ({
   transform: `perspective(900px) rotateX(${tiltX.value}deg) rotateY(${tiltY.value}deg) translateZ(0)`,
+  animationDelay: `${(props.data.index ?? 0) * 55}ms`,
 }))
-
 const shineStyle = computed(() => ({
-  background: `radial-gradient(circle at ${shineX.value}% ${shineY.value}%, rgba(255,255,255,0.18) 0%, transparent 65%)`,
+  background: `radial-gradient(circle at ${shineX.value}% ${shineY.value}%, rgba(255,255,255,0.08) 0%, transparent 65%)`,
 }))
 </script>
 
 <style scoped>
-/* ── Root ─────────────────────────────────────────────── */
+/* NR colour tokens
+   --nr-green:       #00AC69  (brand primary)
+   --nr-green-dark:  #007D4A  (hover / border)
+   --nr-green-dim:   rgba(0,172,105,x) */
+
 .rn {
   position: relative;
-  width: 290px;
-  border-radius: 16px;
-  padding: 14px 16px;
+  width: 240px;
+  border-radius: 10px;
+  padding: 12px 14px;
   cursor: pointer;
   isolation: isolate;
   overflow: hidden;
-  transition: transform 0.08s linear, box-shadow 0.25s ease;
   will-change: transform;
-  opacity: 0;
-  translate: 0 12px;
+  transition: transform 0.08s linear, box-shadow 0.2s ease;
+  animation: node-in 0.3s ease both;
 }
-.rn--entered {
-  opacity: 1;
-  translate: 0 0;
-  transition: opacity 0.4s ease, translate 0.4s ease, transform 0.08s linear, box-shadow 0.25s ease;
+@keyframes node-in {
+  from { opacity: 0; translate: 0 8px; }
+  to   { opacity: 1; translate: 0 0; }
 }
 
-/* Status variants */
-.rn--not_started {
-  background: rgba(15, 23, 42, 0.72);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  box-shadow: 0 4px 24px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.06);
+/* ── Dark (NR product dark theme: charcoal #1D252C) ───── */
+.rn--dark.rn--not_started {
+  background: #1d252c;
+  border: 1px solid rgba(0,172,105,0.3);
+  box-shadow: 0 2px 10px rgba(0,0,0,0.45);
 }
-.rn--in_progress {
-  background: rgba(15, 23, 42, 0.80);
+.rn--dark.rn--in_progress {
+  background: #1f2a2e;
   border: 1px solid transparent;
-  box-shadow: 0 4px 32px rgba(99,102,241,0.25), 0 0 60px rgba(99,102,241,0.08);
+  box-shadow: 0 2px 14px rgba(0,172,105,0.18);
 }
-.rn--done {
-  background: rgba(5, 46, 22, 0.65);
-  border: 1px solid rgba(34, 197, 94, 0.3);
-  box-shadow: 0 4px 24px rgba(34,197,94,0.18), inset 0 1px 0 rgba(255,255,255,0.05);
+.rn--dark.rn--done {
+  background: #1a2820;
+  border: 1px solid rgba(0,172,105,0.35);
+  box-shadow: 0 2px 10px rgba(0,0,0,0.4);
 }
+.rn--dark.rn--not_started:hover { box-shadow: 0 4px 18px rgba(0,0,0,0.55), 0 0 12px rgba(0,172,105,0.12); }
+.rn--dark.rn--in_progress:hover { box-shadow: 0 4px 20px rgba(0,172,105,0.22); }
+.rn--dark.rn--done:hover        { box-shadow: 0 4px 18px rgba(0,172,105,0.2); }
 
-.rn--not_started:hover { box-shadow: 0 16px 40px rgba(0,0,0,0.6), 0 0 30px rgba(99,102,241,0.2); }
-.rn--in_progress:hover { box-shadow: 0 16px 48px rgba(99,102,241,0.4), 0 0 60px rgba(99,102,241,0.15); }
-.rn--done:hover        { box-shadow: 0 16px 40px rgba(34,197,94,0.3), 0 0 40px rgba(34,197,94,0.12); }
+/* Title dark */
+.rn--dark .rn__title      { color: #e8edf0; }
+.rn--dark .rn__title--done { color: #6e7a87; text-decoration: line-through; }
 
-/* ── Animated gradient border (in_progress) ──────────── */
+/* ── Light ──────────────────────────────────────────────── */
+.rn--light.rn--not_started {
+  background: #ffffff;
+  border: 1px solid #b2dfce;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.07);
+}
+.rn--light.rn--in_progress {
+  background: #f0faf5;
+  border: 1px solid transparent;
+  box-shadow: 0 2px 10px rgba(0,172,105,0.14), 0 0 0 1px #7ecfb0;
+}
+.rn--light.rn--done {
+  background: #e8f7f0;
+  border: 1px solid #7ecfb0;
+  box-shadow: 0 1px 6px rgba(0,0,0,0.05);
+}
+.rn--light.rn--not_started:hover { box-shadow: 0 4px 14px rgba(0,0,0,0.1), 0 0 0 1px #7ecfb0; }
+.rn--light.rn--in_progress:hover { box-shadow: 0 4px 16px rgba(0,172,105,0.18), 0 0 0 1px #00AC69; }
+.rn--light.rn--done:hover        { box-shadow: 0 4px 14px rgba(0,172,105,0.16), 0 0 0 1px #00AC69; }
+
+.rn--light .rn__title      { color: #1a2e25; }
+.rn--light .rn__title--done { color: #8f9ab8; text-decoration: line-through; }
+
+/* ── Animated border (in_progress) ─────────────────────── */
 .rn__border-anim {
-  position: absolute;
-  inset: -2px;
-  border-radius: 18px;
-  z-index: -1;
-  background: conic-gradient(from var(--angle, 0deg), #6366f1, #06b6d4, #8b5cf6, #ec4899, #6366f1);
-  animation: spin-border 3s linear infinite;
+  position: absolute; inset: -2px; border-radius: 12px; z-index: -1;
+  background: conic-gradient(from var(--angle, 0deg), #00AC69, #00d97e, #007D4A, #00AC69);
+  animation: spin-border 4s linear infinite;
 }
 @property --angle { syntax: '<angle>'; initial-value: 0deg; inherits: false; }
 @keyframes spin-border { to { --angle: 360deg; } }
 
-/* ── Glass surface ───────────────────────────────────── */
-.rn__glass {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  backdrop-filter: blur(16px) saturate(180%);
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  pointer-events: none;
-  z-index: 0;
-}
+/* Shine */
+.rn__shine { position: absolute; inset: 0; border-radius: inherit; pointer-events: none; z-index: 1; transition: background 0.05s; }
 
-/* ── Mouse-follow shine ──────────────────────────────── */
-.rn__shine {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  z-index: 1;
-  transition: background 0.05s;
-}
-
-/* ── Content ─────────────────────────────────────────── */
-.rn__content {
-  position: relative;
-  z-index: 2;
-}
-
-.rn__header {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  margin-bottom: 8px;
-}
+/* Content */
+.rn__content { position: relative; z-index: 2; }
+.rn__header  { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 8px; }
 
 /* Badge */
 .rn__badge {
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 11px;
-  font-weight: 800;
-  margin-top: 1px;
+  flex-shrink: 0; width: 24px; height: 24px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 10px; font-weight: 800; margin-top: 1px;
 }
-.rn__badge--not_started {
-  background: rgba(99,102,241,0.15);
-  border: 1.5px solid rgba(99,102,241,0.4);
-  color: #a5b4fc;
-}
-.rn__badge--in_progress {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  border: none;
-  color: #fff;
-  box-shadow: 0 0 12px rgba(99,102,241,0.6);
-}
-.rn__badge--done {
-  background: linear-gradient(135deg, #22c55e, #16a34a);
-  border: none;
-  color: #fff;
-  box-shadow: 0 0 12px rgba(34,197,94,0.5);
-}
-.rn__check { width: 13px; height: 13px; }
-.rn__num { line-height: 1; }
+.rn__badge--not_started { background: rgba(0,172,105,0.15); border: 1.5px solid rgba(0,172,105,0.5); color: #00AC69; }
+.rn__badge--in_progress { background: #00AC69; border: none; color: #fff; }
+.rn__badge--done        { background: #007D4A; border: none; color: #fff; }
+.rn__check { width: 12px; height: 12px; }
+.rn__num   { line-height: 1; }
 
-/* Title */
-.rn__title {
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: #e2e8f0;
-  line-height: 1.4;
-  flex: 1;
-  min-width: 0;
-  font-family: 'Inter', system-ui, sans-serif;
-}
-.rn__title--done {
-  color: #4b7a5e;
-  text-decoration: line-through;
-}
+/* Title base */
+.rn__title { font-size: 0.8rem; font-weight: 600; line-height: 1.4; flex: 1; min-width: 0; font-family: 'Inter', system-ui, sans-serif; }
 
-/* Meta tags */
-.rn__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  margin-top: 4px;
-}
+/* Meta */
+.rn__meta { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
 .rn__tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  padding: 2px 7px;
-  border-radius: 99px;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  font-family: 'Inter', system-ui, sans-serif;
+  display: inline-flex; align-items: center; gap: 3px; padding: 2px 6px;
+  border-radius: 4px; font-size: 9px; font-weight: 600; letter-spacing: 0.03em;
+  text-transform: uppercase; font-family: 'Inter', system-ui, sans-serif;
 }
 .rn__tag svg { width: 9px; height: 9px; }
-.rn__tag--course      { background: rgba(99,102,241,0.15); color: #a5b4fc; border: 1px solid rgba(99,102,241,0.25); }
-.rn__tag--res         { background: rgba(14,165,233,0.12); color: #7dd3fc; border: 1px solid rgba(14,165,233,0.2); }
-.rn__tag--not_started { background: rgba(99,102,241,0.1);  color: #818cf8; border: 1px solid rgba(99,102,241,0.2); }
-.rn__tag--in_progress { background: rgba(139,92,246,0.15); color: #c4b5fd; border: 1px solid rgba(139,92,246,0.3); }
-.rn__tag--done        { background: rgba(34,197,94,0.12);  color: #86efac; border: 1px solid rgba(34,197,94,0.25); }
 
-/* ── Glow orb (decorative) ───────────────────────────── */
-.rn__orb {
-  position: absolute;
-  width: 120px;
-  height: 120px;
-  border-radius: 50%;
-  right: -40px;
-  bottom: -50px;
-  pointer-events: none;
-  z-index: 0;
-  filter: blur(40px);
-  opacity: 0.4;
-}
-.rn__orb--not_started { background: rgba(99,102,241,0.4); }
-.rn__orb--in_progress { background: rgba(139,92,246,0.6); animation: pulse-orb 2s ease-in-out infinite; }
-.rn__orb--done        { background: rgba(34,197,94,0.4); }
+/* Light tags */
+.rn__tag--course      { background: #e0f5ec; color: #007D4A; border: 1px solid #b2dfce; }
+.rn__tag--res         { background: #e0f5ec; color: #007D4A; border: 1px solid #b2dfce; }
+.rn__tag--not_started { background: #f0f5f3; color: #5a7a6e; border: 1px solid #c8ddd6; }
+.rn__tag--in_progress { background: #e0f5ec; color: #007D4A; border: 1px solid #7ecfb0; }
+.rn__tag--done        { background: #d0eedf; color: #005c34; border: 1px solid #7ecfb0; }
 
-@keyframes pulse-orb {
-  0%, 100% { opacity: 0.35; transform: scale(1); }
-  50%       { opacity: 0.6;  transform: scale(1.15); }
-}
+/* Dark tag overrides */
+.rn--dark .rn__tag--course      { background: rgba(0,172,105,0.14); color: #5dd9a4; border-color: rgba(0,172,105,0.28); }
+.rn--dark .rn__tag--res         { background: rgba(0,172,105,0.12); color: #5dd9a4; border-color: rgba(0,172,105,0.24); }
+.rn--dark .rn__tag--not_started { background: rgba(110,122,135,0.2); color: #8f9ab8; border-color: rgba(110,122,135,0.3); }
+.rn--dark .rn__tag--in_progress { background: rgba(0,172,105,0.18); color: #5dd9a4; border-color: rgba(0,172,105,0.32); }
+.rn--dark .rn__tag--done        { background: rgba(0,172,105,0.22); color: #3dcc8f; border-color: rgba(0,172,105,0.38); }
 </style>

--- a/frontend/composables/useMyClients.ts
+++ b/frontend/composables/useMyClients.ts
@@ -1,0 +1,100 @@
+export interface ClientSummary {
+  id: number
+  fullname: string
+  email: string
+  profile: {
+    profession?: string
+    level?: string
+    profile_image_url?: string | null
+  } | null
+  path_count: number
+  progress_pct: number
+  done_steps: number
+  total_steps: number
+}
+
+export interface ClientPath {
+  id: number
+  name: string
+  description?: string
+  done_count: number
+  total_count: number
+  steps: Array<{
+    id: number
+    order: number
+    title: string
+    type: string
+    course: { id: number; name: string } | null
+    user_status: 'not_started' | 'in_progress' | 'done'
+  }>
+}
+
+export interface ClientDetail {
+  user: {
+    id: number
+    fullname: string
+    email: string
+    profile: {
+      profession?: string
+      level?: string
+      goal?: string
+      stack?: string[]
+      availability_hours?: number
+      timeline?: string
+      product_interest?: string
+      profile_image_url?: string | null
+      linkedin?: string
+      github?: string
+    } | null
+  }
+  paths: ClientPath[]
+}
+
+export function useMyClients() {
+  const api     = useApi()
+  const clients = ref<ClientSummary[]>([])
+  const loading = ref(false)
+  const error   = ref<string | null>(null)
+
+  async function fetchMyClients() {
+    loading.value = true
+    error.value   = null
+    try {
+      const res = await api.get<{ data: ClientSummary[] }>('/my-clients')
+      clients.value = res.data
+      return res.data
+    } catch (e: any) {
+      error.value = e?.data?.message ?? 'Failed to load clients'
+      return []
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchClientDetail(clientId: number): Promise<ClientDetail | null> {
+    try {
+      return await api.get<ClientDetail>(`/my-clients/${clientId}`)
+    } catch (e: any) {
+      error.value = e?.data?.message ?? 'Failed to load client'
+      return null
+    }
+  }
+
+  async function assignPath(clientId: number, pathId: number) {
+    await api.post(`/my-clients/${clientId}/paths`, { path_id: pathId })
+  }
+
+  async function removePath(clientId: number, pathId: number) {
+    await api.delete(`/my-clients/${clientId}/paths/${pathId}`)
+  }
+
+  return {
+    clients: readonly(clients),
+    loading: readonly(loading),
+    error:   readonly(error),
+    fetchMyClients,
+    fetchClientDetail,
+    assignPath,
+    removePath,
+  }
+}

--- a/frontend/composables/usePaths.ts
+++ b/frontend/composables/usePaths.ts
@@ -1,8 +1,14 @@
+export type StepType = 'reading' | 'lab' | 'challenge' | 'quiz'
+
 export interface PathStep {
   id: number
   path_id: number
   title: string
   description?: string
+  type: StepType
+  lab_url?: string | null
+  instructions?: Array<{ id: number; text: string }>
+  challenge_prompt?: string | null
   resources?: Array<{ label: string; url: string }>
   order: number
   course?: { id: number; name: string; slug: string } | null
@@ -136,6 +142,11 @@ export const usePaths = () => {
     return res.data
   }
 
+  const fetchStep = async (stepId: number): Promise<PathStep & { user_status: string }> => {
+    const res = await api.get(`/path-steps/${stepId}`) as { data: PathStep & { user_status: string } }
+    return res.data
+  }
+
   const createStep = async (pathId: number, data: Partial<PathStep>) => {
     return api.post(`/paths/${pathId}/steps`, data) as Promise<{ data: PathStep }>
   }
@@ -168,6 +179,7 @@ export const usePaths = () => {
     updatePath,
     deletePath,
     fetchSteps,
+    fetchStep,
     createStep,
     updateStep,
     deleteStep,

--- a/frontend/layouts/admin.vue
+++ b/frontend/layouts/admin.vue
@@ -154,7 +154,7 @@
                     :class="n.read ? 'opacity-60' : ''"
                     @click="handleNotificationClick(n, close)"
                   >
-                    <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900/40">
+                    <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/40">
                       <UIcon name="i-heroicons-user-plus" class="h-4 w-4 text-emerald-500" />
                     </span>
                     <div class="min-w-0 flex-1">

--- a/frontend/layouts/admin.vue
+++ b/frontend/layouts/admin.vue
@@ -14,7 +14,7 @@
     ]">
 
       <!-- Accent stripe -->
-      <div class="h-0.5 w-full shrink-0" style="background:linear-gradient(90deg,#6366f1,#06b6d4,#8b5cf6)"></div>
+      <div class="h-0.5 w-full shrink-0" style="background:linear-gradient(90deg,#00AC69,#00d97e,#007D4A)"></div>
 
       <!-- Brand -->
       <div class="flex h-[60px] shrink-0 items-center justify-center border-b border-gray-100 px-5 dark:border-slate-800">
@@ -129,7 +129,7 @@
               <span
                 v-if="unreadCount > 0"
                 class="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center
-                       rounded-full bg-indigo-500 text-[9px] font-bold text-white"
+                       rounded-full bg-emerald-500 text-[9px] font-bold text-white"
               >{{ unreadCount > 9 ? '9+' : unreadCount }}</span>
             </div>
             <template #panel="{ close }">
@@ -138,7 +138,7 @@
                   <p class="text-sm font-semibold text-gray-900 dark:text-white">Notifications</p>
                   <button
                     v-if="unreadCount > 0"
-                    class="text-xs text-indigo-500 hover:underline"
+                    class="text-xs text-emerald-500 hover:underline"
                     @click="markAllRead"
                   >Mark all read</button>
                 </div>
@@ -154,8 +154,8 @@
                     :class="n.read ? 'opacity-60' : ''"
                     @click="handleNotificationClick(n, close)"
                   >
-                    <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-indigo-100 dark:bg-indigo-900/40">
-                      <UIcon name="i-heroicons-user-plus" class="h-4 w-4 text-indigo-500" />
+                    <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-teal-100 dark:bg-teal-900/40">
+                      <UIcon name="i-heroicons-user-plus" class="h-4 w-4 text-emerald-500" />
                     </span>
                     <div class="min-w-0 flex-1">
                       <p class="text-[13px] font-medium text-gray-800 dark:text-slate-200 leading-snug">
@@ -171,7 +171,7 @@
                         {{ timeAgo(n.created_at) }}
                       </p>
                     </div>
-                    <span v-if="!n.read" class="mt-2 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />
+                    <span v-if="!n.read" class="mt-2 h-2 w-2 shrink-0 rounded-full bg-emerald-500" />
                   </li>
                 </ul>
               </div>
@@ -245,55 +245,46 @@ watch(() => route.path, () => { sidebarOpen.value = false })
 const isDark      = computed(() => colorMode.value === 'dark')
 const isAdmin     = computed(() => user.value?.role === 'admin')
 const isStaff     = computed(() => ['admin', 'consultant'].includes(user.value?.role ?? ''))
-const isActive    = (p: string) => route.path === p
+const isActive    = (p: string) => route.path === p || (p !== '/dashboard' && route.path.startsWith(p + '/'))
 
 const toggleColorMode = () => { colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark' }
 const handleLogout    = () => logout()
 
-// ── Neon values injected into CSS via v-bind() ──────────────
-// Active item background
+// ── Nav colours — New Relic green palette ───────────────────
 const navActiveBg = computed(() =>
-  isDark.value ? 'rgba(99,102,241,0.12)' : 'rgb(238,242,255)'
+  isDark.value ? 'rgba(0,172,105,0.12)' : 'rgb(240,250,245)'
 )
-// Active item text colour
 const navActiveTxt = computed(() =>
-  isDark.value ? 'rgb(165,180,252)' : 'rgb(79,70,229)'
+  isDark.value ? 'rgb(93,217,164)' : 'rgb(0,125,74)'
 )
-// Active left-bar colour
 const navBarColor = computed(() =>
-  isDark.value ? '#818cf8' : '#6366f1'
+  isDark.value ? '#00AC69' : '#007D4A'
 )
-// Neon glow (dark mode only)
 const navGlowColor = computed(() =>
-  isDark.value
-    ? 'rgba(99,102,241,0.35)'
-    : 'transparent'
+  isDark.value ? 'rgba(0,172,105,0.3)' : 'transparent'
 )
-// Icon active colour
 const navIconActive = computed(() =>
-  isDark.value ? 'rgb(129,140,248)' : 'rgb(99,102,241)'
+  isDark.value ? 'rgb(93,217,164)' : 'rgb(0,125,74)'
 )
-// Icon idle colour
 const navIconIdle = computed(() =>
   isDark.value ? 'rgb(148,163,184)' : 'rgb(156,163,175)'
 )
-// Idle text
 const navIdleTxt = computed(() =>
   isDark.value ? 'rgb(148,163,184)' : 'rgb(75,85,99)'
 )
-// Idle hover bg
 const navHoverBg = computed(() =>
-  isDark.value ? 'rgba(255,255,255,0.04)' : 'rgb(249,250,251)'
+  isDark.value ? 'rgba(0,172,105,0.06)' : 'rgb(240,250,245)'
 )
 
 const mainItems = computed(() => {
   if (isStaff.value) {
     const items = [
-      { label: 'Dashboard', icon: 'i-heroicons-home',                      to: '/dashboard' },
-      { label: 'Courses',   icon: 'i-heroicons-book-open',               to: '/courses' },
-      { label: 'Paths',     icon: 'i-heroicons-map',                     to: '/paths' },
-      { label: 'Plans',     icon: 'i-heroicons-clipboard-document-list', to: '/plans' },
-      { label: 'Jobs',      icon: 'i-heroicons-briefcase',               to: '/jobs' },
+      { label: 'Dashboard',  icon: 'i-heroicons-home',                      to: '/dashboard' },
+      { label: 'My Clients', icon: 'i-heroicons-user-group',               to: '/my-clients' },
+      { label: 'Courses',    icon: 'i-heroicons-book-open',                to: '/courses' },
+      { label: 'Paths',      icon: 'i-heroicons-map',                      to: '/paths' },
+      { label: 'Plans',      icon: 'i-heroicons-clipboard-document-list',  to: '/plans' },
+      { label: 'Jobs',       icon: 'i-heroicons-briefcase',                to: '/jobs' },
     ]
     if (isAdmin.value) {
       items.splice(1, 0, { label: 'Users', icon: 'i-heroicons-users', to: '/users' })
@@ -378,10 +369,10 @@ const breadcrumbLinks = computed(() => {
 
 /* Brand wordmark — dark mode gradient + glow */
 .brand-glow {
-  background: linear-gradient(90deg, #818cf8, #38bdf8, #a78bfa);
+  background: linear-gradient(90deg, #00AC69, #00d97e, #5dd9a4);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
-  filter: drop-shadow(0 0 8px rgba(129, 140, 248, 0.6));
+  filter: drop-shadow(0 0 8px rgba(0, 172, 105, 0.5));
 }
 </style>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -14,6 +14,11 @@ export default defineNuxtConfig({
 
   modules: ['@nuxt/ui'],
 
+  ui: {
+    primary: 'emerald',
+    gray: 'slate',
+  },
+
   colorMode: {
     preference: 'dark'
   },

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -3,7 +3,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-24">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-indigo-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
     </div>
 
     <!-- Error -->
@@ -48,8 +48,8 @@
           <!-- Course info card -->
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="flex items-center gap-4 border-b border-gray-100 px-6 py-5 dark:border-gray-700">
-              <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-indigo-50 dark:bg-indigo-950">
-                <UIcon name="i-heroicons-book-open" class="h-7 w-7 text-indigo-500" />
+              <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-teal-50 dark:bg-teal-950">
+                <UIcon name="i-heroicons-book-open" class="h-7 w-7 text-teal-500" />
               </div>
               <div>
                 <h2 class="text-base font-bold text-gray-900 dark:text-white">{{ course.name }}</h2>
@@ -87,7 +87,7 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="p-6">
               <div class="mb-4 text-center">
-                <p class="text-xs font-semibold uppercase tracking-widest text-indigo-500 dark:text-indigo-400">
+                <p class="text-xs font-semibold uppercase tracking-widest text-teal-500 dark:text-teal-400">
                   Ready to start?
                 </p>
                 <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
@@ -97,7 +97,7 @@
               <a
                 :href="`https://wa.me/353894050730?text=Hi%2C+I%27d+like+to+start+the+course+%22${encodeURIComponent(course.name)}%22.+Can+you+help+me+get+access%3F`"
                 target="_blank"
-                class="block w-full rounded-lg bg-indigo-600 px-4 py-3 text-center text-sm font-semibold
+                class="block w-full rounded-lg bg-teal-600 px-4 py-3 text-center text-sm font-semibold
                        text-white transition-opacity hover:opacity-90"
               >
                 Request Access via WhatsApp

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -3,7 +3,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-24">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
     </div>
 
     <!-- Error -->
@@ -48,8 +48,8 @@
           <!-- Course info card -->
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="flex items-center gap-4 border-b border-gray-100 px-6 py-5 dark:border-gray-700">
-              <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-teal-50 dark:bg-teal-950">
-                <UIcon name="i-heroicons-book-open" class="h-7 w-7 text-teal-500" />
+              <div class="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-950">
+                <UIcon name="i-heroicons-book-open" class="h-7 w-7 text-emerald-500" />
               </div>
               <div>
                 <h2 class="text-base font-bold text-gray-900 dark:text-white">{{ course.name }}</h2>
@@ -87,7 +87,7 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="p-6">
               <div class="mb-4 text-center">
-                <p class="text-xs font-semibold uppercase tracking-widest text-teal-500 dark:text-teal-400">
+                <p class="text-xs font-semibold uppercase tracking-widest text-emerald-500 dark:text-emerald-400">
                   Ready to start?
                 </p>
                 <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
@@ -97,7 +97,7 @@
               <a
                 :href="`https://wa.me/353894050730?text=Hi%2C+I%27d+like+to+start+the+course+%22${encodeURIComponent(course.name)}%22.+Can+you+help+me+get+access%3F`"
                 target="_blank"
-                class="block w-full rounded-lg bg-teal-600 px-4 py-3 text-center text-sm font-semibold
+                class="block w-full rounded-lg bg-emerald-600 px-4 py-3 text-center text-sm font-semibold
                        text-white transition-opacity hover:opacity-90"
               >
                 Request Access via WhatsApp

--- a/frontend/pages/courses/index.vue
+++ b/frontend/pages/courses/index.vue
@@ -200,7 +200,7 @@ const isAdmin = computed(() => user.value?.role === 'admin')
 
 // Clients have no business on the management page
 onMounted(() => {
-  if (!isAdmin.value) router.replace('/my-courses')
+  if (user.value?.role === 'client') router.replace('/my-courses')
 })
 
 const searchQuery = ref('')

--- a/frontend/pages/dashboard.vue
+++ b/frontend/pages/dashboard.vue
@@ -68,7 +68,7 @@
 
           <!-- Card body -->
           <div class="px-5 py-4">
-            <div v-if="statsLoading" class="flex justify-center py-8 text-indigo-500">
+            <div v-if="statsLoading" class="flex justify-center py-8 text-teal-500">
               <UIcon name="i-heroicons-arrow-path" class="animate-spin text-xl" />
             </div>
 
@@ -106,14 +106,14 @@
                   v-for="path in clientPaths"
                   :key="path.id"
                   class="cursor-pointer rounded-xl border border-gray-100 p-4 transition-colors
-                         hover:border-indigo-200 hover:bg-indigo-50/30
-                         dark:border-gray-700 dark:hover:border-indigo-800 dark:hover:bg-indigo-950/20"
+                         hover:border-teal-200 hover:bg-teal-50/30
+                         dark:border-gray-700 dark:hover:border-teal-800 dark:hover:bg-teal-950/20"
                   @click="navigateTo('/my-paths')"
                 >
                   <div class="flex items-start justify-between gap-3">
                     <div class="flex items-center gap-3">
-                      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-50 dark:bg-indigo-950">
-                        <UIcon name="i-heroicons-map" class="h-5 w-5 text-indigo-500" />
+                      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-teal-50 dark:bg-teal-950">
+                        <UIcon name="i-heroicons-map" class="h-5 w-5 text-teal-500" />
                       </div>
                       <div>
                         <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ path.name }}</p>
@@ -128,11 +128,11 @@
                   </div>
 
                   <!-- Progress bar -->
-                  <UProgress :value="path.pct" size="xs" color="indigo" class="mt-3" />
+                  <UProgress :value="path.pct" size="xs" color="teal" class="mt-3" />
 
                   <!-- Next step -->
                   <div v-if="path.nextStep" class="mt-3 flex items-center gap-2">
-                    <UIcon name="i-heroicons-arrow-right-circle" class="h-4 w-4 shrink-0 text-indigo-400" />
+                    <UIcon name="i-heroicons-arrow-right-circle" class="h-4 w-4 shrink-0 text-teal-400" />
                     <span class="text-xs text-gray-500 dark:text-gray-400">
                       Next: <span class="font-medium text-gray-700 dark:text-gray-300">{{ path.nextStep }}</span>
                     </span>
@@ -146,14 +146,14 @@
 
               <!-- Empty state -->
               <div v-else class="flex flex-col items-center py-10 text-center">
-                <div class="mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950">
-                  <UIcon name="i-heroicons-map" class="h-8 w-8 text-indigo-400" />
+                <div class="mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
+                  <UIcon name="i-heroicons-map" class="h-8 w-8 text-teal-400" />
                 </div>
                 <p class="text-sm font-medium text-gray-700 dark:text-gray-300">No learning paths yet</p>
                 <p class="mt-1 max-w-xs text-xs text-gray-400 dark:text-gray-500">
                   Your consultant will assign a personalised learning path based on your goals.
                 </p>
-                <UButton size="xs" color="indigo" variant="soft" class="mt-4" @click="navigateTo('/my-paths')">
+                <UButton size="xs" color="teal" variant="soft" class="mt-4" @click="navigateTo('/my-paths')">
                   Learn more
                 </UButton>
               </div>
@@ -294,7 +294,7 @@ const getUserActions = (u: any) => [[
 
 function progressColor(pct: number) {
   if (pct >= 75) return 'text-green-600 dark:text-green-400'
-  if (pct >= 40) return 'text-indigo-600 dark:text-indigo-400'
+  if (pct >= 40) return 'text-teal-600 dark:text-teal-400'
   return 'text-gray-500 dark:text-gray-400'
 }
 

--- a/frontend/pages/dashboard.vue
+++ b/frontend/pages/dashboard.vue
@@ -68,7 +68,7 @@
 
           <!-- Card body -->
           <div class="px-5 py-4">
-            <div v-if="statsLoading" class="flex justify-center py-8 text-teal-500">
+            <div v-if="statsLoading" class="flex justify-center py-8 text-emerald-500">
               <UIcon name="i-heroicons-arrow-path" class="animate-spin text-xl" />
             </div>
 
@@ -106,14 +106,14 @@
                   v-for="path in clientPaths"
                   :key="path.id"
                   class="cursor-pointer rounded-xl border border-gray-100 p-4 transition-colors
-                         hover:border-teal-200 hover:bg-teal-50/30
-                         dark:border-gray-700 dark:hover:border-teal-800 dark:hover:bg-teal-950/20"
+                         hover:border-emerald-200 hover:bg-emerald-50/30
+                         dark:border-gray-700 dark:hover:border-emerald-800 dark:hover:bg-emerald-950/20"
                   @click="navigateTo('/my-paths')"
                 >
                   <div class="flex items-start justify-between gap-3">
                     <div class="flex items-center gap-3">
-                      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-teal-50 dark:bg-teal-950">
-                        <UIcon name="i-heroicons-map" class="h-5 w-5 text-teal-500" />
+                      <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-950">
+                        <UIcon name="i-heroicons-map" class="h-5 w-5 text-emerald-500" />
                       </div>
                       <div>
                         <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ path.name }}</p>
@@ -128,11 +128,11 @@
                   </div>
 
                   <!-- Progress bar -->
-                  <UProgress :value="path.pct" size="xs" color="teal" class="mt-3" />
+                  <UProgress :value="path.pct" size="xs" color="emerald" class="mt-3" />
 
                   <!-- Next step -->
                   <div v-if="path.nextStep" class="mt-3 flex items-center gap-2">
-                    <UIcon name="i-heroicons-arrow-right-circle" class="h-4 w-4 shrink-0 text-teal-400" />
+                    <UIcon name="i-heroicons-arrow-right-circle" class="h-4 w-4 shrink-0 text-emerald-400" />
                     <span class="text-xs text-gray-500 dark:text-gray-400">
                       Next: <span class="font-medium text-gray-700 dark:text-gray-300">{{ path.nextStep }}</span>
                     </span>
@@ -146,14 +146,14 @@
 
               <!-- Empty state -->
               <div v-else class="flex flex-col items-center py-10 text-center">
-                <div class="mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
-                  <UIcon name="i-heroicons-map" class="h-8 w-8 text-teal-400" />
+                <div class="mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+                  <UIcon name="i-heroicons-map" class="h-8 w-8 text-emerald-400" />
                 </div>
                 <p class="text-sm font-medium text-gray-700 dark:text-gray-300">No learning paths yet</p>
                 <p class="mt-1 max-w-xs text-xs text-gray-400 dark:text-gray-500">
                   Your consultant will assign a personalised learning path based on your goals.
                 </p>
-                <UButton size="xs" color="teal" variant="soft" class="mt-4" @click="navigateTo('/my-paths')">
+                <UButton size="xs" color="emerald" variant="soft" class="mt-4" @click="navigateTo('/my-paths')">
                   Learn more
                 </UButton>
               </div>
@@ -294,7 +294,7 @@ const getUserActions = (u: any) => [[
 
 function progressColor(pct: number) {
   if (pct >= 75) return 'text-green-600 dark:text-green-400'
-  if (pct >= 40) return 'text-teal-600 dark:text-teal-400'
+  if (pct >= 40) return 'text-emerald-600 dark:text-emerald-400'
   return 'text-gray-500 dark:text-gray-400'
 }
 

--- a/frontend/pages/labs/[id].vue
+++ b/frontend/pages/labs/[id].vue
@@ -3,7 +3,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex h-[70vh] items-center justify-center">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
     </div>
 
     <template v-else-if="step">
@@ -27,10 +27,10 @@
         <!-- Progress + status -->
         <div class="flex items-center gap-3 shrink-0">
           <div v-if="step.instructions?.length" class="text-right">
-            <p class="text-xs font-semibold" :class="allDone ? 'text-teal-600 dark:text-teal-400' : 'text-gray-500'">
+            <p class="text-xs font-semibold" :class="allDone ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-500'">
               {{ checkedCount }} / {{ step.instructions.length }} completed
             </p>
-            <UProgress :value="progressPct" size="xs" color="teal" class="w-28 mt-1" />
+            <UProgress :value="progressPct" size="xs" color="emerald" class="w-28 mt-1" />
           </div>
           <UBadge :color="statusColor" variant="subtle">{{ statusLabel }}</UBadge>
         </div>
@@ -50,12 +50,12 @@
 
           <!-- Challenge prompt -->
           <div v-if="step.challenge_prompt"
-            class="rounded-xl border border-teal-200 bg-teal-50 dark:border-teal-800/40 dark:bg-teal-950/20 p-4">
+            class="rounded-xl border border-emerald-200 bg-emerald-50 dark:border-emerald-800/40 dark:bg-emerald-950/20 p-4">
             <div class="flex items-center gap-2 mb-2">
-              <UIcon name="i-heroicons-bolt" class="h-4 w-4 text-teal-600 dark:text-teal-400" />
-              <p class="text-xs font-bold text-teal-700 dark:text-teal-400 uppercase tracking-wide">Challenge</p>
+              <UIcon name="i-heroicons-bolt" class="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+              <p class="text-xs font-bold text-emerald-700 dark:text-emerald-400 uppercase tracking-wide">Challenge</p>
             </div>
-            <p class="text-sm text-teal-800 dark:text-teal-300 leading-relaxed">{{ step.challenge_prompt }}</p>
+            <p class="text-sm text-emerald-800 dark:text-emerald-300 leading-relaxed">{{ step.challenge_prompt }}</p>
           </div>
 
           <!-- Instructions checklist -->
@@ -74,8 +74,8 @@
                   <div
                     class="h-5 w-5 rounded-full border-2 flex items-center justify-center transition-all"
                     :class="checked.has(inst.id)
-                      ? 'border-teal-500 bg-teal-500'
-                      : 'border-gray-300 dark:border-gray-600 group-hover:border-teal-400'"
+                      ? 'border-emerald-500 bg-emerald-500'
+                      : 'border-gray-300 dark:border-gray-600 group-hover:border-emerald-400'"
                     @click="toggleCheck(inst.id)"
                   >
                     <UIcon v-if="checked.has(inst.id)" name="i-heroicons-check" class="h-3 w-3 text-white" />
@@ -100,7 +100,7 @@
             <p class="mb-3 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Resources</p>
             <div class="flex flex-col gap-2">
               <a v-for="r in step.resources" :key="r.url" :href="r.url" target="_blank"
-                class="flex items-center gap-2 text-sm text-teal-600 hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 hover:underline">
+                class="flex items-center gap-2 text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 hover:underline">
                 <UIcon name="i-heroicons-arrow-top-right-on-square" class="h-3.5 w-3.5 shrink-0" />
                 {{ r.label }}
               </a>
@@ -113,7 +113,7 @@
             <div class="flex flex-col gap-2">
               <UButton
                 block
-                color="teal"
+                color="emerald"
                 variant="solid"
                 icon="i-heroicons-check-circle"
                 :loading="saving"
@@ -154,7 +154,7 @@
               </span>
             </div>
             <a v-if="step.lab_url" :href="step.lab_url" target="_blank"
-              class="flex items-center gap-1 text-xs text-gray-500 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
+              class="flex items-center gap-1 text-xs text-gray-500 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors">
               <UIcon name="i-heroicons-arrow-top-right-on-square" class="h-3.5 w-3.5" />
               Open in new tab
             </a>
@@ -246,7 +246,7 @@ async function markStatus(status: 'in_progress' | 'done') {
   try {
     await updateStepProgress(step.value.id, status)
     step.value = { ...step.value, user_status: status }
-    toast.add({ title: status === 'done' ? 'Step completed!' : 'Marked as in progress', color: 'teal' })
+    toast.add({ title: status === 'done' ? 'Step completed!' : 'Marked as in progress', color: 'emerald' })
   } catch {
     toast.add({ title: 'Could not save progress', color: 'red' })
   } finally {
@@ -270,7 +270,7 @@ const typeIcon = computed(() => ({
 }[step.value?.type ?? 'reading']))
 
 const typeBadgeColor = computed(() => ({
-  lab:       'teal',
+  lab:       'emerald',
   challenge: 'amber',
   quiz:      'violet',
   reading:   'gray',
@@ -284,7 +284,7 @@ const statusLabel = computed(() => ({
 
 const statusColor = computed(() => ({
   done:        'green',
-  in_progress: 'teal',
+  in_progress: 'emerald',
   not_started: 'gray',
 }[step.value?.user_status ?? 'not_started']))
 </script>

--- a/frontend/pages/labs/[id].vue
+++ b/frontend/pages/labs/[id].vue
@@ -1,0 +1,290 @@
+<template>
+  <NuxtLayout name="admin">
+
+    <!-- Loading -->
+    <div v-if="loading" class="flex h-[70vh] items-center justify-center">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+    </div>
+
+    <template v-else-if="step">
+      <!-- Header -->
+      <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
+        <div class="flex items-center gap-3 min-w-0">
+          <UButton icon="i-heroicons-arrow-left" size="sm" color="gray" variant="ghost" @click="router.back()" />
+          <div class="min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <UBadge :color="typeBadgeColor" variant="subtle" size="xs" :icon="typeIcon">
+                {{ typeLabel }}
+              </UBadge>
+              <h1 class="text-lg font-bold text-gray-900 dark:text-white truncate">{{ step.title }}</h1>
+            </div>
+            <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+              Step {{ step.order }} · {{ step.course?.name ?? 'No linked course' }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Progress + status -->
+        <div class="flex items-center gap-3 shrink-0">
+          <div v-if="step.instructions?.length" class="text-right">
+            <p class="text-xs font-semibold" :class="allDone ? 'text-teal-600 dark:text-teal-400' : 'text-gray-500'">
+              {{ checkedCount }} / {{ step.instructions.length }} completed
+            </p>
+            <UProgress :value="progressPct" size="xs" color="teal" class="w-28 mt-1" />
+          </div>
+          <UBadge :color="statusColor" variant="subtle">{{ statusLabel }}</UBadge>
+        </div>
+      </div>
+
+      <!-- Main split layout -->
+      <div class="flex gap-4 h-[calc(100vh-180px)] min-h-[500px]">
+
+        <!-- ── Left panel: instructions ─────────────────── -->
+        <div class="w-80 shrink-0 flex flex-col gap-4 overflow-y-auto pr-1">
+
+          <!-- Description -->
+          <div v-if="step.description"
+            class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-4">
+            <p class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed">{{ step.description }}</p>
+          </div>
+
+          <!-- Challenge prompt -->
+          <div v-if="step.challenge_prompt"
+            class="rounded-xl border border-teal-200 bg-teal-50 dark:border-teal-800/40 dark:bg-teal-950/20 p-4">
+            <div class="flex items-center gap-2 mb-2">
+              <UIcon name="i-heroicons-bolt" class="h-4 w-4 text-teal-600 dark:text-teal-400" />
+              <p class="text-xs font-bold text-teal-700 dark:text-teal-400 uppercase tracking-wide">Challenge</p>
+            </div>
+            <p class="text-sm text-teal-800 dark:text-teal-300 leading-relaxed">{{ step.challenge_prompt }}</p>
+          </div>
+
+          <!-- Instructions checklist -->
+          <div v-if="step.instructions?.length"
+            class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-4">
+            <p class="mb-3 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+              Instructions
+            </p>
+            <div class="flex flex-col gap-2">
+              <label
+                v-for="inst in step.instructions"
+                :key="inst.id"
+                class="flex items-start gap-3 cursor-pointer group"
+              >
+                <div class="mt-0.5 shrink-0">
+                  <div
+                    class="h-5 w-5 rounded-full border-2 flex items-center justify-center transition-all"
+                    :class="checked.has(inst.id)
+                      ? 'border-teal-500 bg-teal-500'
+                      : 'border-gray-300 dark:border-gray-600 group-hover:border-teal-400'"
+                    @click="toggleCheck(inst.id)"
+                  >
+                    <UIcon v-if="checked.has(inst.id)" name="i-heroicons-check" class="h-3 w-3 text-white" />
+                  </div>
+                </div>
+                <span
+                  class="text-sm leading-relaxed transition-colors"
+                  :class="checked.has(inst.id)
+                    ? 'text-gray-400 line-through dark:text-gray-500'
+                    : 'text-gray-700 dark:text-gray-300'"
+                  @click="toggleCheck(inst.id)"
+                >
+                  {{ inst.text }}
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <!-- External resources -->
+          <div v-if="step.resources?.length"
+            class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-4">
+            <p class="mb-3 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Resources</p>
+            <div class="flex flex-col gap-2">
+              <a v-for="r in step.resources" :key="r.url" :href="r.url" target="_blank"
+                class="flex items-center gap-2 text-sm text-teal-600 hover:text-teal-700 dark:text-teal-400 dark:hover:text-teal-300 hover:underline">
+                <UIcon name="i-heroicons-arrow-top-right-on-square" class="h-3.5 w-3.5 shrink-0" />
+                {{ r.label }}
+              </a>
+            </div>
+          </div>
+
+          <!-- Mark complete / in-progress actions -->
+          <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-4 mt-auto">
+            <p class="mb-3 text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Your Progress</p>
+            <div class="flex flex-col gap-2">
+              <UButton
+                block
+                color="teal"
+                variant="solid"
+                icon="i-heroicons-check-circle"
+                :loading="saving"
+                :disabled="hasInstructions && !allDone"
+                @click="markStatus('done')"
+              >
+                {{ step.user_status === 'done' ? 'Completed ✓' : 'Mark as Done' }}
+              </UButton>
+              <UButton
+                v-if="step.user_status !== 'in_progress'"
+                block
+                color="gray"
+                variant="outline"
+                icon="i-heroicons-play-circle"
+                :loading="saving"
+                @click="markStatus('in_progress')"
+              >
+                Mark In Progress
+              </UButton>
+              <p v-if="hasInstructions && !allDone" class="text-xs text-center text-gray-400 dark:text-gray-500">
+                Complete all {{ step.instructions!.length }} instructions first
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- ── Right panel: embedded environment ─────────── -->
+        <div class="flex-1 flex flex-col rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
+
+          <!-- Toolbar -->
+          <div class="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 shrink-0">
+            <div class="flex items-center gap-2">
+              <div class="h-3 w-3 rounded-full bg-red-400" />
+              <div class="h-3 w-3 rounded-full bg-yellow-400" />
+              <div class="h-3 w-3 rounded-full bg-green-400" />
+              <span class="ml-2 text-xs text-gray-500 dark:text-gray-400 font-mono truncate max-w-xs">
+                {{ step.lab_url ?? 'No environment configured' }}
+              </span>
+            </div>
+            <a v-if="step.lab_url" :href="step.lab_url" target="_blank"
+              class="flex items-center gap-1 text-xs text-gray-500 hover:text-teal-600 dark:hover:text-teal-400 transition-colors">
+              <UIcon name="i-heroicons-arrow-top-right-on-square" class="h-3.5 w-3.5" />
+              Open in new tab
+            </a>
+          </div>
+
+          <!-- iframe or empty state -->
+          <div class="flex-1 bg-gray-100 dark:bg-gray-900">
+            <iframe
+              v-if="step.lab_url"
+              :src="step.lab_url"
+              class="w-full h-full border-0"
+              allow="cross-origin-isolated"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
+            />
+            <div v-else class="flex h-full flex-col items-center justify-center text-center p-8">
+              <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-200 dark:bg-gray-700">
+                <UIcon name="i-heroicons-command-line" class="h-8 w-8 text-gray-400" />
+              </div>
+              <p class="text-sm font-semibold text-gray-600 dark:text-gray-400">No lab environment linked</p>
+              <p class="mt-1 text-xs text-gray-400 dark:text-gray-500 max-w-xs">
+                Ask your consultant to link a StackBlitz, Killercoda, or GitHub Codespace to this step.
+              </p>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </template>
+
+  </NuxtLayout>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: false, middleware: 'auth' })
+
+const route  = useRoute()
+const router = useRouter()
+const toast  = useToast()
+
+const { fetchStep, updateStepProgress } = usePaths()
+
+const step   = ref<any>(null)
+const loading = ref(true)
+const saving  = ref(false)
+
+// ── Instruction checkboxes (persisted in localStorage) ──
+const checked = ref(new Set<number>())
+const storageKey = computed(() => `lab-progress-${route.params.id}`)
+
+onMounted(async () => {
+  try {
+    step.value = await fetchStep(Number(route.params.id))
+    // Restore checked state from localStorage
+    const saved = localStorage.getItem(storageKey.value)
+    if (saved) {
+      const ids: number[] = JSON.parse(saved)
+      checked.value = new Set(ids)
+    }
+  } finally {
+    loading.value = false
+  }
+})
+
+useHead(() => ({ title: step.value ? `${step.value.title} — Lab` : 'Lab — CODECV' }))
+
+function toggleCheck(id: number) {
+  if (checked.value.has(id)) {
+    checked.value.delete(id)
+  } else {
+    checked.value.add(id)
+  }
+  // Persist
+  localStorage.setItem(storageKey.value, JSON.stringify([...checked.value]))
+}
+
+const hasInstructions = computed(() => (step.value?.instructions?.length ?? 0) > 0)
+const checkedCount    = computed(() => checked.value.size)
+const allDone         = computed(() =>
+  !hasInstructions.value || checked.value.size >= (step.value?.instructions?.length ?? 0)
+)
+const progressPct = computed(() => {
+  const total = step.value?.instructions?.length ?? 0
+  return total ? Math.round((checked.value.size / total) * 100) : 0
+})
+
+async function markStatus(status: 'in_progress' | 'done') {
+  if (saving.value) return
+  saving.value = true
+  try {
+    await updateStepProgress(step.value.id, status)
+    step.value = { ...step.value, user_status: status }
+    toast.add({ title: status === 'done' ? 'Step completed!' : 'Marked as in progress', color: 'teal' })
+  } catch {
+    toast.add({ title: 'Could not save progress', color: 'red' })
+  } finally {
+    saving.value = false
+  }
+}
+
+// ── Presentation helpers ────────────────────────────────
+const typeLabel = computed(() => ({
+  lab:       'Hands-on Lab',
+  challenge: 'Challenge',
+  quiz:      'Quiz',
+  reading:   'Reading',
+}[step.value?.type ?? 'reading']))
+
+const typeIcon = computed(() => ({
+  lab:       'i-heroicons-command-line',
+  challenge: 'i-heroicons-bolt',
+  quiz:      'i-heroicons-question-mark-circle',
+  reading:   'i-heroicons-book-open',
+}[step.value?.type ?? 'reading']))
+
+const typeBadgeColor = computed(() => ({
+  lab:       'teal',
+  challenge: 'amber',
+  quiz:      'violet',
+  reading:   'gray',
+}[step.value?.type ?? 'reading']))
+
+const statusLabel = computed(() => ({
+  done:        'Done',
+  in_progress: 'In Progress',
+  not_started: 'Not Started',
+}[step.value?.user_status ?? 'not_started']))
+
+const statusColor = computed(() => ({
+  done:        'green',
+  in_progress: 'teal',
+  not_started: 'gray',
+}[step.value?.user_status ?? 'not_started']))
+</script>

--- a/frontend/pages/linkedin-analyser.vue
+++ b/frontend/pages/linkedin-analyser.vue
@@ -9,7 +9,7 @@
           Share your LinkedIn profile and career goal — AI will tell you exactly what to improve.
         </p>
       </div>
-      <UBadge color="indigo" variant="subtle" size="sm" class="items-center gap-1.5">
+      <UBadge color="teal" variant="subtle" size="sm" class="items-center gap-1.5">
         <UIcon name="i-heroicons-sparkles" class="h-3.5 w-3.5" />
         Powered by CODECV
       </UBadge>
@@ -34,19 +34,19 @@
                 class="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed px-6 py-8 transition-colors"
                 :class="linkedinPdf
                   ? 'border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-950/20'
-                  : 'border-gray-200 hover:border-indigo-300 dark:border-gray-600 dark:hover:border-indigo-600'"
+                  : 'border-gray-200 hover:border-teal-300 dark:border-gray-600 dark:hover:border-teal-600'"
               >
                 <UIcon
                   :name="linkedinPdf ? 'i-heroicons-document-check' : 'i-heroicons-document-arrow-up'"
                   class="h-7 w-7"
-                  :class="linkedinPdf ? 'text-green-500' : 'text-indigo-400'"
+                  :class="linkedinPdf ? 'text-green-500' : 'text-teal-400'"
                 />
                 <div class="text-center">
                   <p v-if="linkedinPdf" class="text-sm font-semibold text-green-700 dark:text-green-400">
                     {{ linkedinPdf.name }}
                   </p>
                   <p v-else class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Drop PDF here or <span class="text-indigo-600 dark:text-indigo-400">browse</span>
+                    Drop PDF here or <span class="text-teal-600 dark:text-teal-400">browse</span>
                   </p>
                   <p class="mt-1 text-xs text-gray-400">PDF only · max 5 MB</p>
                 </div>
@@ -81,9 +81,9 @@
                 maxlength="200"
                 class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm
                        text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-200
+                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-indigo-500 dark:focus:bg-gray-800"
+                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
               />
             </div>
 
@@ -99,9 +99,9 @@
                 maxlength="100"
                 class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm
                        text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-200
+                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-indigo-500 dark:focus:bg-gray-800"
+                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
               />
             </div>
 
@@ -118,9 +118,9 @@
                 placeholder="e.g. 5"
                 class="w-32 rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm
                        text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-200
+                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-indigo-500 dark:focus:bg-gray-800"
+                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
               />
             </div>
           </div>
@@ -129,7 +129,7 @@
         <!-- Analyse button -->
         <UButton
           size="lg"
-          color="indigo"
+          color="teal"
           block
           :loading="analysing"
           :disabled="!canAnalyse || analysing"
@@ -152,8 +152,8 @@
         <div v-if="!result && !analysing"
           class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200
                  bg-white py-20 text-center dark:border-gray-700 dark:bg-gray-800">
-          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950">
-            <UIcon name="i-heroicons-identification" class="h-8 w-8 text-indigo-300" />
+          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
+            <UIcon name="i-heroicons-identification" class="h-8 w-8 text-teal-300" />
           </div>
           <p class="text-sm font-medium text-gray-400 dark:text-gray-500">Results will appear here</p>
           <p class="mt-1 text-xs text-gray-300 dark:text-gray-600">Fill in the form to get your analysis</p>
@@ -163,7 +163,7 @@
         <div v-else-if="analysing" class="flex flex-col gap-5">
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-6">
             <div class="flex flex-col items-center gap-4 py-6">
-              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-indigo-400" />
+              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-teal-400" />
               <div class="text-center">
                 <p class="text-sm font-semibold text-gray-900 dark:text-white">Analysing your profile…</p>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CODECV is reading your LinkedIn and building your personalised report.</p>
@@ -208,14 +208,14 @@
           </div>
 
           <!-- Headline & Summary suggestions -->
-          <div class="rounded-xl border border-indigo-100 bg-indigo-50 dark:border-indigo-900/40 dark:bg-indigo-950/20">
-            <div class="border-b border-indigo-100 px-5 py-4 dark:border-indigo-900/40">
-              <h3 class="flex items-center gap-2 text-sm font-semibold text-indigo-800 dark:text-indigo-300">
+          <div class="rounded-xl border border-teal-100 bg-teal-50 dark:border-teal-900/40 dark:bg-teal-950/20">
+            <div class="border-b border-teal-100 px-5 py-4 dark:border-teal-900/40">
+              <h3 class="flex items-center gap-2 text-sm font-semibold text-teal-800 dark:text-teal-300">
                 <UIcon name="i-heroicons-pencil-square" class="h-4 w-4" />
                 Suggested Headline
               </h3>
             </div>
-            <p class="px-5 py-4 text-sm text-indigo-700 dark:text-indigo-300 italic">
+            <p class="px-5 py-4 text-sm text-teal-700 dark:text-teal-300 italic">
               "{{ result.headline_suggestion }}"
             </p>
           </div>
@@ -223,7 +223,7 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="border-b border-gray-100 px-5 py-4 dark:border-gray-700">
               <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                <UIcon name="i-heroicons-document-text" class="h-4 w-4 text-indigo-500" />
+                <UIcon name="i-heroicons-document-text" class="h-4 w-4 text-teal-500" />
                 Suggested About Section
               </h3>
             </div>
@@ -263,13 +263,13 @@
           <!-- Skills to add -->
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-5">
             <p class="mb-3 flex items-center gap-1.5 text-xs font-semibold text-gray-700 dark:text-gray-300">
-              <UIcon name="i-heroicons-plus-circle" class="h-4 w-4 text-indigo-500" />
+              <UIcon name="i-heroicons-plus-circle" class="h-4 w-4 text-teal-500" />
               Skills / Certifications to Add
             </p>
             <div class="flex flex-wrap gap-1.5">
               <span v-for="skill in result.skills_to_add" :key="skill"
-                class="rounded-full bg-indigo-50 px-2.5 py-1 text-xs font-medium text-indigo-700
-                       dark:bg-indigo-900/40 dark:text-indigo-300">
+                class="rounded-full bg-teal-50 px-2.5 py-1 text-xs font-medium text-teal-700
+                       dark:bg-teal-900/40 dark:text-teal-300">
                 {{ skill }}
               </span>
             </div>
@@ -279,15 +279,15 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="border-b border-gray-100 px-5 py-4 dark:border-gray-700">
               <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-indigo-500" />
+                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-teal-500" />
                 Action Plan
               </h3>
             </div>
             <ul class="divide-y divide-gray-100 dark:divide-gray-700">
               <li v-for="(rec, i) in result.recommendations" :key="rec"
                 class="flex items-start gap-3 px-5 py-3 text-sm text-gray-700 dark:text-gray-300">
-                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-50
-                             text-[10px] font-bold text-indigo-600 dark:bg-indigo-950 dark:text-indigo-400">
+                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-50
+                             text-[10px] font-bold text-teal-600 dark:bg-teal-950 dark:text-teal-400">
                   {{ i + 1 }}
                 </span>
                 {{ rec }}

--- a/frontend/pages/linkedin-analyser.vue
+++ b/frontend/pages/linkedin-analyser.vue
@@ -9,7 +9,7 @@
           Share your LinkedIn profile and career goal — AI will tell you exactly what to improve.
         </p>
       </div>
-      <UBadge color="teal" variant="subtle" size="sm" class="items-center gap-1.5">
+      <UBadge color="emerald" variant="subtle" size="sm" class="items-center gap-1.5">
         <UIcon name="i-heroicons-sparkles" class="h-3.5 w-3.5" />
         Powered by CODECV
       </UBadge>
@@ -34,19 +34,19 @@
                 class="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed px-6 py-8 transition-colors"
                 :class="linkedinPdf
                   ? 'border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-950/20'
-                  : 'border-gray-200 hover:border-teal-300 dark:border-gray-600 dark:hover:border-teal-600'"
+                  : 'border-gray-200 hover:border-emerald-300 dark:border-gray-600 dark:hover:border-emerald-600'"
               >
                 <UIcon
                   :name="linkedinPdf ? 'i-heroicons-document-check' : 'i-heroicons-document-arrow-up'"
                   class="h-7 w-7"
-                  :class="linkedinPdf ? 'text-green-500' : 'text-teal-400'"
+                  :class="linkedinPdf ? 'text-green-500' : 'text-emerald-400'"
                 />
                 <div class="text-center">
                   <p v-if="linkedinPdf" class="text-sm font-semibold text-green-700 dark:text-green-400">
                     {{ linkedinPdf.name }}
                   </p>
                   <p v-else class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    Drop PDF here or <span class="text-teal-600 dark:text-teal-400">browse</span>
+                    Drop PDF here or <span class="text-emerald-600 dark:text-emerald-400">browse</span>
                   </p>
                   <p class="mt-1 text-xs text-gray-400">PDF only · max 5 MB</p>
                 </div>
@@ -81,9 +81,9 @@
                 maxlength="200"
                 class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm
                        text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
+                       focus:border-emerald-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
+                       dark:focus:border-emerald-500 dark:focus:bg-gray-800"
               />
             </div>
 
@@ -99,9 +99,9 @@
                 maxlength="100"
                 class="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm
                        text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
+                       focus:border-emerald-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
+                       dark:focus:border-emerald-500 dark:focus:bg-gray-800"
               />
             </div>
 
@@ -118,9 +118,9 @@
                 placeholder="e.g. 5"
                 class="w-32 rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-sm
                        text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
+                       focus:border-emerald-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
+                       dark:focus:border-emerald-500 dark:focus:bg-gray-800"
               />
             </div>
           </div>
@@ -129,7 +129,7 @@
         <!-- Analyse button -->
         <UButton
           size="lg"
-          color="teal"
+          color="emerald"
           block
           :loading="analysing"
           :disabled="!canAnalyse || analysing"
@@ -152,8 +152,8 @@
         <div v-if="!result && !analysing"
           class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200
                  bg-white py-20 text-center dark:border-gray-700 dark:bg-gray-800">
-          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
-            <UIcon name="i-heroicons-identification" class="h-8 w-8 text-teal-300" />
+          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+            <UIcon name="i-heroicons-identification" class="h-8 w-8 text-emerald-300" />
           </div>
           <p class="text-sm font-medium text-gray-400 dark:text-gray-500">Results will appear here</p>
           <p class="mt-1 text-xs text-gray-300 dark:text-gray-600">Fill in the form to get your analysis</p>
@@ -163,7 +163,7 @@
         <div v-else-if="analysing" class="flex flex-col gap-5">
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-6">
             <div class="flex flex-col items-center gap-4 py-6">
-              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-teal-400" />
+              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-emerald-400" />
               <div class="text-center">
                 <p class="text-sm font-semibold text-gray-900 dark:text-white">Analysing your profile…</p>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CODECV is reading your LinkedIn and building your personalised report.</p>
@@ -208,14 +208,14 @@
           </div>
 
           <!-- Headline & Summary suggestions -->
-          <div class="rounded-xl border border-teal-100 bg-teal-50 dark:border-teal-900/40 dark:bg-teal-950/20">
-            <div class="border-b border-teal-100 px-5 py-4 dark:border-teal-900/40">
-              <h3 class="flex items-center gap-2 text-sm font-semibold text-teal-800 dark:text-teal-300">
+          <div class="rounded-xl border border-emerald-100 bg-emerald-50 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+            <div class="border-b border-emerald-100 px-5 py-4 dark:border-emerald-900/40">
+              <h3 class="flex items-center gap-2 text-sm font-semibold text-emerald-800 dark:text-emerald-300">
                 <UIcon name="i-heroicons-pencil-square" class="h-4 w-4" />
                 Suggested Headline
               </h3>
             </div>
-            <p class="px-5 py-4 text-sm text-teal-700 dark:text-teal-300 italic">
+            <p class="px-5 py-4 text-sm text-emerald-700 dark:text-emerald-300 italic">
               "{{ result.headline_suggestion }}"
             </p>
           </div>
@@ -223,7 +223,7 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="border-b border-gray-100 px-5 py-4 dark:border-gray-700">
               <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                <UIcon name="i-heroicons-document-text" class="h-4 w-4 text-teal-500" />
+                <UIcon name="i-heroicons-document-text" class="h-4 w-4 text-emerald-500" />
                 Suggested About Section
               </h3>
             </div>
@@ -263,13 +263,13 @@
           <!-- Skills to add -->
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-5">
             <p class="mb-3 flex items-center gap-1.5 text-xs font-semibold text-gray-700 dark:text-gray-300">
-              <UIcon name="i-heroicons-plus-circle" class="h-4 w-4 text-teal-500" />
+              <UIcon name="i-heroicons-plus-circle" class="h-4 w-4 text-emerald-500" />
               Skills / Certifications to Add
             </p>
             <div class="flex flex-wrap gap-1.5">
               <span v-for="skill in result.skills_to_add" :key="skill"
-                class="rounded-full bg-teal-50 px-2.5 py-1 text-xs font-medium text-teal-700
-                       dark:bg-teal-900/40 dark:text-teal-300">
+                class="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700
+                       dark:bg-emerald-900/40 dark:text-emerald-300">
                 {{ skill }}
               </span>
             </div>
@@ -279,15 +279,15 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="border-b border-gray-100 px-5 py-4 dark:border-gray-700">
               <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-teal-500" />
+                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-emerald-500" />
                 Action Plan
               </h3>
             </div>
             <ul class="divide-y divide-gray-100 dark:divide-gray-700">
               <li v-for="(rec, i) in result.recommendations" :key="rec"
                 class="flex items-start gap-3 px-5 py-3 text-sm text-gray-700 dark:text-gray-300">
-                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-50
-                             text-[10px] font-bold text-teal-600 dark:bg-teal-950 dark:text-teal-400">
+                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-50
+                             text-[10px] font-bold text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
                   {{ i + 1 }}
                 </span>
                 {{ rec }}

--- a/frontend/pages/my-clients/[id].vue
+++ b/frontend/pages/my-clients/[id].vue
@@ -1,0 +1,350 @@
+<template>
+  <NuxtLayout name="admin">
+
+    <!-- Back -->
+    <div class="mb-5">
+      <NuxtLink to="/my-clients"
+        class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors">
+        <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" />
+        My Clients
+      </NuxtLink>
+    </div>
+
+    <div v-if="loading" class="flex justify-center py-20">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
+    </div>
+
+    <template v-else-if="detail">
+
+      <!-- Client header -->
+      <div class="mb-6 flex flex-wrap items-start gap-5 rounded-xl border border-gray-200 bg-white p-6
+                  dark:border-gray-700 dark:bg-gray-800">
+        <UAvatar
+          :src="detail.user.profile?.profile_image_url ?? undefined"
+          :alt="detail.user.fullname"
+          size="xl"
+          :ui="{ background: 'bg-emerald-100 dark:bg-emerald-900' }"
+        />
+        <div class="min-w-0 flex-1">
+          <h1 class="text-xl font-bold text-gray-900 dark:text-white">{{ detail.user.fullname }}</h1>
+          <p class="text-sm text-gray-500 dark:text-gray-400">{{ detail.user.email }}</p>
+
+          <div v-if="detail.user.profile" class="mt-3 flex flex-wrap gap-2 text-xs text-gray-600 dark:text-gray-300">
+            <span v-if="detail.user.profile.profession" class="flex items-center gap-1">
+              <UIcon name="i-heroicons-briefcase" class="h-3.5 w-3.5" />
+              {{ detail.user.profile.profession }}
+            </span>
+            <span v-if="detail.user.profile.level" class="flex items-center gap-1">
+              <UIcon name="i-heroicons-signal" class="h-3.5 w-3.5" />
+              {{ detail.user.profile.level }}
+            </span>
+            <span v-if="detail.user.profile.availability_hours" class="flex items-center gap-1">
+              <UIcon name="i-heroicons-clock" class="h-3.5 w-3.5" />
+              {{ detail.user.profile.availability_hours }}h/week
+            </span>
+            <span v-if="detail.user.profile.timeline" class="flex items-center gap-1">
+              <UIcon name="i-heroicons-calendar" class="h-3.5 w-3.5" />
+              {{ detail.user.profile.timeline }}
+            </span>
+          </div>
+
+          <p v-if="detail.user.profile?.goal" class="mt-2 max-w-lg text-sm text-gray-500 dark:text-gray-400 italic">
+            "{{ detail.user.profile.goal }}"
+          </p>
+        </div>
+
+        <!-- Overall progress pill -->
+        <div class="flex shrink-0 flex-col items-end gap-1.5">
+          <span class="text-2xl font-black" :class="progressColor(overallPct)">{{ overallPct }}%</span>
+          <UProgress :value="overallPct" size="sm" color="emerald" class="w-32" />
+          <span class="text-xs text-gray-400">{{ totalDone }} / {{ totalSteps }} steps done</span>
+        </div>
+      </div>
+
+      <!-- Assign path button -->
+      <div class="mb-4 flex items-center justify-between">
+        <h2 class="text-base font-semibold text-gray-900 dark:text-white">Training Paths</h2>
+        <UButton
+          color="emerald"
+          variant="solid"
+          size="sm"
+          icon="i-heroicons-plus"
+          @click="showAssignModal = true"
+        >
+          Assign Path
+        </UButton>
+      </div>
+
+      <!-- Empty paths -->
+      <div v-if="!detail.paths.length"
+        class="flex flex-col items-center rounded-xl border border-dashed border-gray-200 py-14 text-center
+               dark:border-gray-700">
+        <UIcon name="i-heroicons-map" class="mb-3 h-10 w-10 text-gray-300 dark:text-gray-600" />
+        <p class="text-sm font-medium text-gray-500 dark:text-gray-400">No paths assigned yet.</p>
+        <UButton class="mt-4" color="emerald" variant="soft" size="sm" @click="showAssignModal = true">
+          Assign the first path
+        </UButton>
+      </div>
+
+      <!-- Path cards -->
+      <div v-else class="flex flex-col gap-5">
+        <div v-for="clientPath in detail.paths" :key="clientPath.id"
+          class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+
+          <!-- Path header -->
+          <div class="flex flex-wrap items-center gap-3 border-b border-gray-100 p-4 dark:border-gray-700">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50 dark:bg-emerald-950">
+              <UIcon name="i-heroicons-map" class="h-5 w-5 text-emerald-500" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="font-semibold text-gray-900 dark:text-white">{{ clientPath.name }}</p>
+              <p v-if="clientPath.description" class="text-xs text-gray-500 dark:text-gray-400">{{ clientPath.description }}</p>
+            </div>
+            <div class="flex shrink-0 items-center gap-3">
+              <div class="text-right">
+                <p class="text-sm font-bold" :class="progressColor(pathPct(clientPath))">
+                  {{ pathPct(clientPath) }}%
+                </p>
+                <p class="text-xs text-gray-400">{{ clientPath.done_count }}/{{ clientPath.total_count }}</p>
+              </div>
+              <UProgress :value="pathPct(clientPath)" size="sm" color="emerald" class="w-24" />
+              <UButton
+                color="red"
+                variant="ghost"
+                size="xs"
+                icon="i-heroicons-trash"
+                :loading="removing.has(clientPath.id)"
+                @click="confirmRemove(clientPath)"
+              />
+            </div>
+          </div>
+
+          <!-- Steps list -->
+          <div class="divide-y divide-gray-50 dark:divide-gray-700/50">
+            <div v-for="step in clientPath.steps" :key="step.id"
+              class="flex items-center gap-3 px-4 py-2.5">
+              <!-- Status dot -->
+              <div class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold"
+                :class="stepDotClass(step.user_status)">
+                <UIcon v-if="step.user_status === 'done'" name="i-heroicons-check" class="h-3.5 w-3.5" />
+                <span v-else>{{ step.order }}</span>
+              </div>
+              <p class="flex-1 text-sm" :class="step.user_status === 'done'
+                ? 'text-gray-400 line-through dark:text-gray-500'
+                : 'text-gray-700 dark:text-gray-200'">
+                {{ step.title }}
+              </p>
+              <UBadge :color="statusColor(step.user_status)" variant="subtle" size="xs">
+                {{ statusLabel(step.user_status) }}
+              </UBadge>
+              <UBadge v-if="step.type && step.type !== 'reading'" color="blue" variant="soft" size="xs">
+                {{ step.type }}
+              </UBadge>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </template>
+
+    <!-- Assign Path Modal -->
+    <UModal v-model="showAssignModal">
+      <UCard :ui="{ ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-700' }">
+        <template #header>
+          <p class="text-base font-semibold text-gray-900 dark:text-white">Assign a Learning Path</p>
+        </template>
+
+        <div class="space-y-3 py-2">
+          <UFormGroup label="Search paths">
+            <UInput v-model="pathSearch" placeholder="Type to filter…" icon="i-heroicons-magnifying-glass" />
+          </UFormGroup>
+
+          <div v-if="loadingPaths" class="flex justify-center py-6">
+            <UIcon name="i-heroicons-arrow-path" class="animate-spin text-emerald-500" />
+          </div>
+          <div v-else-if="!availablePaths.length" class="py-4 text-center text-sm text-gray-400">
+            No paths found.
+          </div>
+          <div v-else class="max-h-64 overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-700">
+            <button
+              v-for="p in availablePaths"
+              :key="p.id"
+              class="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-emerald-50 dark:hover:bg-emerald-950/30"
+              :class="selectedPathId === p.id ? 'bg-emerald-50 dark:bg-emerald-950/40' : ''"
+              @click="selectedPathId = p.id"
+            >
+              <UIcon
+                :name="selectedPathId === p.id ? 'i-heroicons-check-circle' : 'i-heroicons-circle-stack'"
+                class="h-5 w-5 shrink-0"
+                :class="selectedPathId === p.id ? 'text-emerald-500' : 'text-gray-400'"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ p.name }}</p>
+                <p v-if="p.description" class="truncate text-xs text-gray-500 dark:text-gray-400">{{ p.description }}</p>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <template #footer>
+          <div class="flex justify-end gap-2">
+            <UButton color="gray" variant="ghost" @click="showAssignModal = false">Cancel</UButton>
+            <UButton
+              color="emerald"
+              :disabled="!selectedPathId"
+              :loading="assigning"
+              @click="doAssignPath"
+            >
+              Assign Path
+            </UButton>
+          </div>
+        </template>
+      </UCard>
+    </UModal>
+
+    <!-- Remove confirm modal -->
+    <UModal v-model="showRemoveModal">
+      <UCard :ui="{ ring: '' }">
+        <template #header>
+          <p class="text-base font-semibold text-gray-900 dark:text-white">Remove Path</p>
+        </template>
+        <p class="text-sm text-gray-600 dark:text-gray-300">
+          Remove <strong>{{ pathToRemove?.name }}</strong> from {{ detail?.user.fullname }}'s training plan?
+          Their step progress will not be deleted.
+        </p>
+        <template #footer>
+          <div class="flex justify-end gap-2">
+            <UButton color="gray" variant="ghost" @click="showRemoveModal = false">Cancel</UButton>
+            <UButton color="red" :loading="removing.has(pathToRemove?.id ?? 0)" @click="doRemovePath">
+              Remove
+            </UButton>
+          </div>
+        </template>
+      </UCard>
+    </UModal>
+
+  </NuxtLayout>
+</template>
+
+<script setup lang="ts">
+import type { ClientDetail, ClientPath } from '~/composables/useMyClients'
+import type { Path } from '~/composables/usePaths'
+
+definePageMeta({ layout: false, middleware: 'auth' })
+
+const route = useRoute()
+const toast = useToast()
+const clientId = Number(route.params.id)
+
+const { fetchClientDetail, assignPath, removePath } = useMyClients()
+const { fetchPaths } = usePaths()
+
+useHead({ title: 'Client Detail — CODECV' })
+
+const detail      = ref<ClientDetail | null>(null)
+const loading     = ref(true)
+const assigning   = ref(false)
+const removing    = ref(new Set<number>())
+
+const showAssignModal = ref(false)
+const showRemoveModal = ref(false)
+const pathToRemove    = ref<ClientPath | null>(null)
+const selectedPathId  = ref<number | null>(null)
+const pathSearch      = ref('')
+const allPaths        = ref<Path[]>([])
+const loadingPaths    = ref(false)
+
+onMounted(async () => {
+  detail.value  = await fetchClientDetail(clientId)
+  loading.value = false
+})
+
+watch(showAssignModal, async (open) => {
+  if (!open) { selectedPathId.value = null; pathSearch.value = ''; return }
+  loadingPaths.value = true
+  try {
+    const res = await fetchPaths({ per_page: 100 })
+    allPaths.value = res?.data ?? []
+  } finally {
+    loadingPaths.value = false
+  }
+})
+
+const assignedIds   = computed(() => new Set(detail.value?.paths.map(p => p.id) ?? []))
+const availablePaths = computed(() => {
+  const q = pathSearch.value.toLowerCase()
+  return allPaths.value.filter(p =>
+    !assignedIds.value.has(p.id) &&
+    (!q || p.name.toLowerCase().includes(q))
+  )
+})
+
+const totalSteps = computed(() => detail.value?.paths.reduce((a, p) => a + p.total_count, 0) ?? 0)
+const totalDone  = computed(() => detail.value?.paths.reduce((a, p) => a + p.done_count, 0) ?? 0)
+const overallPct = computed(() => totalSteps.value > 0 ? Math.round(totalDone.value / totalSteps.value * 100) : 0)
+
+function pathPct(p: ClientPath) {
+  return p.total_count > 0 ? Math.round(p.done_count / p.total_count * 100) : 0
+}
+
+async function doAssignPath() {
+  if (!selectedPathId.value) return
+  assigning.value = true
+  try {
+    await assignPath(clientId, selectedPathId.value)
+    detail.value = await fetchClientDetail(clientId)
+    showAssignModal.value = false
+    toast.add({ title: 'Path assigned', color: 'green' })
+  } catch {
+    toast.add({ title: 'Could not assign path', color: 'red' })
+  } finally {
+    assigning.value = false
+  }
+}
+
+function confirmRemove(p: ClientPath) {
+  pathToRemove.value  = p
+  showRemoveModal.value = true
+}
+
+async function doRemovePath() {
+  if (!pathToRemove.value) return
+  const id = pathToRemove.value.id
+  removing.value.add(id)
+  try {
+    await removePath(clientId, id)
+    detail.value = await fetchClientDetail(clientId)
+    showRemoveModal.value = false
+    toast.add({ title: 'Path removed', color: 'green' })
+  } catch {
+    toast.add({ title: 'Could not remove path', color: 'red' })
+  } finally {
+    removing.value.delete(id)
+    pathToRemove.value = null
+  }
+}
+
+function progressColor(pct: number) {
+  if (pct >= 75) return 'text-emerald-600 dark:text-emerald-400'
+  if (pct >= 40) return 'text-blue-600 dark:text-blue-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+
+function stepDotClass(status: string) {
+  if (status === 'done')        return 'bg-emerald-500 text-white'
+  if (status === 'in_progress') return 'bg-blue-500 text-white'
+  return 'border-2 border-gray-300 bg-white text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400'
+}
+
+function statusColor(status: string) {
+  if (status === 'done')        return 'green'
+  if (status === 'in_progress') return 'blue'
+  return 'gray'
+}
+
+function statusLabel(status: string) {
+  if (status === 'done')        return 'Done'
+  if (status === 'in_progress') return 'In Progress'
+  return 'Not Started'
+}
+</script>

--- a/frontend/pages/my-clients/index.vue
+++ b/frontend/pages/my-clients/index.vue
@@ -1,0 +1,97 @@
+<template>
+  <NuxtLayout name="admin">
+
+    <div class="mb-6 flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">My Clients</h1>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Track your clients' progress and manage their training plans.
+        </p>
+      </div>
+    </div>
+
+    <div v-if="loading" class="flex justify-center py-20">
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
+    </div>
+
+    <div v-else-if="!clients.length" class="flex flex-col items-center py-20 text-center">
+      <div class="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+        <UIcon name="i-heroicons-users" class="h-10 w-10 text-emerald-400" />
+      </div>
+      <h3 class="text-base font-semibold text-gray-900 dark:text-white">No clients yet</h3>
+      <p class="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+        Clients assigned to you by an admin will appear here.
+      </p>
+    </div>
+
+    <div v-else class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <NuxtLink
+        v-for="client in clients"
+        :key="client.id"
+        :to="`/my-clients/${client.id}`"
+        class="group rounded-xl border border-gray-200 bg-white p-5 transition-all hover:border-emerald-300 hover:shadow-md
+               dark:border-gray-700 dark:bg-gray-800 dark:hover:border-emerald-700"
+      >
+        <!-- Avatar + name -->
+        <div class="flex items-center gap-3">
+          <UAvatar
+            :src="client.profile?.profile_image_url ?? undefined"
+            :alt="client.fullname"
+            size="md"
+            :ui="{ background: 'bg-emerald-100 dark:bg-emerald-900' }"
+          />
+          <div class="min-w-0 flex-1">
+            <p class="truncate font-semibold text-gray-900 dark:text-white">{{ client.fullname }}</p>
+            <p class="truncate text-xs text-gray-500 dark:text-gray-400">{{ client.email }}</p>
+          </div>
+        </div>
+
+        <!-- Profession + level badges -->
+        <div v-if="client.profile?.profession || client.profile?.level" class="mt-3 flex flex-wrap gap-1.5">
+          <UBadge v-if="client.profile?.profession" color="gray" variant="subtle" size="xs">
+            {{ client.profile.profession }}
+          </UBadge>
+          <UBadge v-if="client.profile?.level" :color="levelColor(client.profile.level)" variant="subtle" size="xs">
+            {{ client.profile.level }}
+          </UBadge>
+        </div>
+
+        <!-- Progress -->
+        <div class="mt-4">
+          <div class="mb-1 flex items-center justify-between text-xs">
+            <span class="text-gray-500 dark:text-gray-400">
+              {{ client.path_count }} path{{ client.path_count !== 1 ? 's' : '' }} ·
+              {{ client.done_steps }}/{{ client.total_steps }} steps done
+            </span>
+            <span class="font-bold" :class="progressColor(client.progress_pct)">
+              {{ client.progress_pct }}%
+            </span>
+          </div>
+          <UProgress :value="client.progress_pct" size="xs" color="emerald" />
+        </div>
+      </NuxtLink>
+    </div>
+
+  </NuxtLayout>
+</template>
+
+<script setup lang="ts">
+definePageMeta({ layout: false, middleware: 'auth' })
+useHead({ title: 'My Clients — CODECV' })
+
+const { clients, loading, fetchMyClients } = useMyClients()
+
+onMounted(fetchMyClients)
+
+function levelColor(level: string) {
+  if (level === 'senior' || level === 'manager') return 'emerald'
+  if (level === 'mid') return 'blue'
+  return 'gray'
+}
+
+function progressColor(pct: number) {
+  if (pct >= 75) return 'text-emerald-600 dark:text-emerald-400'
+  if (pct >= 40) return 'text-blue-600 dark:text-blue-400'
+  return 'text-gray-500 dark:text-gray-400'
+}
+</script>

--- a/frontend/pages/my-courses.vue
+++ b/frontend/pages/my-courses.vue
@@ -37,7 +37,7 @@
       <button v-for="t in tabs" :key="t.value"
         class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px"
         :class="activeTab === t.value
-          ? 'border-teal-600 text-teal-600 dark:text-teal-400 dark:border-teal-400'
+          ? 'border-emerald-600 text-emerald-600 dark:text-emerald-400 dark:border-emerald-400'
           : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'"
         @click="activeTab = t.value">
         {{ t.label }}
@@ -57,7 +57,7 @@
             <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">All courses on the platform</p>
           </div>
           <div class="p-5">
-            <div v-if="catalogLoading" class="flex justify-center py-12 text-teal-500">
+            <div v-if="catalogLoading" class="flex justify-center py-12 text-emerald-500">
               <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
             </div>
             <div v-else-if="!catalog.length" class="py-12 text-center text-sm text-gray-400">
@@ -66,9 +66,9 @@
             <div v-else class="flex flex-col gap-3">
               <div v-for="course in catalog" :key="course.id"
                 class="flex items-start gap-4 rounded-lg border border-gray-100 p-4
-                       dark:border-gray-700 hover:border-teal-200 dark:hover:border-teal-800 transition-colors">
-                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-teal-50 dark:bg-teal-950">
-                  <UIcon name="i-heroicons-book-open" class="h-5 w-5 text-teal-500" />
+                       dark:border-gray-700 hover:border-emerald-200 dark:hover:border-emerald-800 transition-colors">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-50 dark:bg-emerald-950">
+                  <UIcon name="i-heroicons-book-open" class="h-5 w-5 text-emerald-500" />
                 </div>
                 <div class="min-w-0 flex-1">
                   <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ course.name }}</p>
@@ -79,7 +79,7 @@
                     By {{ course.user?.fullname || 'CODECV' }}
                   </p>
                 </div>
-                <UButton size="xs" color="teal" variant="soft"
+                <UButton size="xs" color="emerald" variant="soft"
                   icon="i-heroicons-arrow-right"
                   trailing
                   @click="navigateTo(`/courses/${course.id}`)">
@@ -101,19 +101,19 @@
             <div class="flex gap-1">
               <UButton
                 v-for="f in filters" :key="f.value"
-                size="xs" :color="activeFilter === f.value ? 'teal' : 'gray'"
+                size="xs" :color="activeFilter === f.value ? 'emerald' : 'gray'"
                 :variant="activeFilter === f.value ? 'solid' : 'ghost'"
                 @click="activeFilter = f.value"
               >{{ f.label }}</UButton>
             </div>
           </div>
           <div class="p-5">
-            <div v-if="loading" class="flex justify-center py-12 text-teal-500">
+            <div v-if="loading" class="flex justify-center py-12 text-emerald-500">
               <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
             </div>
             <div v-else class="flex flex-col items-center py-12 text-center">
-              <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
-                <UIcon name="i-heroicons-book-open" class="h-8 w-8 text-teal-400" />
+              <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+                <UIcon name="i-heroicons-book-open" class="h-8 w-8 text-emerald-400" />
               </div>
               <h3 class="text-sm font-semibold text-gray-900 dark:text-white">No enrollments yet</h3>
               <p class="mt-1 max-w-xs text-sm text-gray-500 dark:text-gray-400">
@@ -146,8 +146,8 @@
             <div v-else>
               <p class="mb-3 text-sm font-medium text-gray-900 dark:text-white">{{ activePath.name }}</p>
               <div class="mb-3 flex items-center gap-2">
-                <UProgress :value="activePath.progress" size="md" color="teal" class="flex-1" />
-                <span class="text-sm font-semibold text-teal-600 dark:text-teal-400">{{ activePath.progress }}%</span>
+                <UProgress :value="activePath.progress" size="md" color="emerald" class="flex-1" />
+                <span class="text-sm font-semibold text-emerald-600 dark:text-emerald-400">{{ activePath.progress }}%</span>
               </div>
               <p class="text-xs text-gray-500 dark:text-gray-400">
                 {{ activePath.completed }} of {{ activePath.total }} milestones completed
@@ -183,13 +183,13 @@
 
         <!-- CTA -->
         <div class="rounded-xl p-5 text-white" style="background:linear-gradient(135deg,#4f46e5,#7c3aed)">
-          <p class="text-xs font-semibold uppercase tracking-widest text-teal-200">1-on-1 Mentorship</p>
+          <p class="text-xs font-semibold uppercase tracking-widest text-emerald-200">1-on-1 Mentorship</p>
           <h3 class="mt-2 text-base font-bold">Need guidance from an expert?</h3>
-          <p class="mt-1 text-sm text-teal-100 leading-relaxed">
+          <p class="mt-1 text-sm text-emerald-100 leading-relaxed">
             Book a session with your consultant and accelerate your progress.
           </p>
           <button
-            class="mt-4 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-teal-700
+            class="mt-4 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-emerald-700
                    transition-opacity hover:opacity-90"
             @click="navigateTo('/pricing')"
           >

--- a/frontend/pages/my-courses.vue
+++ b/frontend/pages/my-courses.vue
@@ -37,7 +37,7 @@
       <button v-for="t in tabs" :key="t.value"
         class="px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px"
         :class="activeTab === t.value
-          ? 'border-indigo-600 text-indigo-600 dark:text-indigo-400 dark:border-indigo-400'
+          ? 'border-teal-600 text-teal-600 dark:text-teal-400 dark:border-teal-400'
           : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'"
         @click="activeTab = t.value">
         {{ t.label }}
@@ -57,7 +57,7 @@
             <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">All courses on the platform</p>
           </div>
           <div class="p-5">
-            <div v-if="catalogLoading" class="flex justify-center py-12 text-indigo-500">
+            <div v-if="catalogLoading" class="flex justify-center py-12 text-teal-500">
               <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
             </div>
             <div v-else-if="!catalog.length" class="py-12 text-center text-sm text-gray-400">
@@ -66,9 +66,9 @@
             <div v-else class="flex flex-col gap-3">
               <div v-for="course in catalog" :key="course.id"
                 class="flex items-start gap-4 rounded-lg border border-gray-100 p-4
-                       dark:border-gray-700 hover:border-indigo-200 dark:hover:border-indigo-800 transition-colors">
-                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-950">
-                  <UIcon name="i-heroicons-book-open" class="h-5 w-5 text-indigo-500" />
+                       dark:border-gray-700 hover:border-teal-200 dark:hover:border-teal-800 transition-colors">
+                <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-teal-50 dark:bg-teal-950">
+                  <UIcon name="i-heroicons-book-open" class="h-5 w-5 text-teal-500" />
                 </div>
                 <div class="min-w-0 flex-1">
                   <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ course.name }}</p>
@@ -79,7 +79,7 @@
                     By {{ course.user?.fullname || 'CODECV' }}
                   </p>
                 </div>
-                <UButton size="xs" color="indigo" variant="soft"
+                <UButton size="xs" color="teal" variant="soft"
                   icon="i-heroicons-arrow-right"
                   trailing
                   @click="navigateTo(`/courses/${course.id}`)">
@@ -101,19 +101,19 @@
             <div class="flex gap-1">
               <UButton
                 v-for="f in filters" :key="f.value"
-                size="xs" :color="activeFilter === f.value ? 'indigo' : 'gray'"
+                size="xs" :color="activeFilter === f.value ? 'teal' : 'gray'"
                 :variant="activeFilter === f.value ? 'solid' : 'ghost'"
                 @click="activeFilter = f.value"
               >{{ f.label }}</UButton>
             </div>
           </div>
           <div class="p-5">
-            <div v-if="loading" class="flex justify-center py-12 text-indigo-500">
+            <div v-if="loading" class="flex justify-center py-12 text-teal-500">
               <UIcon name="i-heroicons-arrow-path" class="animate-spin text-2xl" />
             </div>
             <div v-else class="flex flex-col items-center py-12 text-center">
-              <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950">
-                <UIcon name="i-heroicons-book-open" class="h-8 w-8 text-indigo-400" />
+              <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
+                <UIcon name="i-heroicons-book-open" class="h-8 w-8 text-teal-400" />
               </div>
               <h3 class="text-sm font-semibold text-gray-900 dark:text-white">No enrollments yet</h3>
               <p class="mt-1 max-w-xs text-sm text-gray-500 dark:text-gray-400">
@@ -146,8 +146,8 @@
             <div v-else>
               <p class="mb-3 text-sm font-medium text-gray-900 dark:text-white">{{ activePath.name }}</p>
               <div class="mb-3 flex items-center gap-2">
-                <UProgress :value="activePath.progress" size="md" color="indigo" class="flex-1" />
-                <span class="text-sm font-semibold text-indigo-600 dark:text-indigo-400">{{ activePath.progress }}%</span>
+                <UProgress :value="activePath.progress" size="md" color="teal" class="flex-1" />
+                <span class="text-sm font-semibold text-teal-600 dark:text-teal-400">{{ activePath.progress }}%</span>
               </div>
               <p class="text-xs text-gray-500 dark:text-gray-400">
                 {{ activePath.completed }} of {{ activePath.total }} milestones completed
@@ -183,13 +183,13 @@
 
         <!-- CTA -->
         <div class="rounded-xl p-5 text-white" style="background:linear-gradient(135deg,#4f46e5,#7c3aed)">
-          <p class="text-xs font-semibold uppercase tracking-widest text-indigo-200">1-on-1 Mentorship</p>
+          <p class="text-xs font-semibold uppercase tracking-widest text-teal-200">1-on-1 Mentorship</p>
           <h3 class="mt-2 text-base font-bold">Need guidance from an expert?</h3>
-          <p class="mt-1 text-sm text-indigo-100 leading-relaxed">
+          <p class="mt-1 text-sm text-teal-100 leading-relaxed">
             Book a session with your consultant and accelerate your progress.
           </p>
           <button
-            class="mt-4 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-indigo-700
+            class="mt-4 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-teal-700
                    transition-opacity hover:opacity-90"
             @click="navigateTo('/pricing')"
           >

--- a/frontend/pages/my-cv.vue
+++ b/frontend/pages/my-cv.vue
@@ -9,7 +9,7 @@
           Upload your CV and provide a job posting — AI will score the match and suggest improvements.
         </p>
       </div>
-      <UBadge color="teal" variant="subtle" size="sm" class="items-center gap-1.5">
+      <UBadge color="emerald" variant="subtle" size="sm" class="items-center gap-1.5">
         <UIcon name="i-heroicons-sparkles" class="h-3.5 w-3.5" />
         Powered by CODECV
       </UBadge>
@@ -32,20 +32,20 @@
               class="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed
                      px-6 py-10 transition-colors"
               :class="dragOver
-                ? 'border-teal-400 bg-teal-50 dark:border-teal-500 dark:bg-teal-950/30'
+                ? 'border-emerald-400 bg-emerald-50 dark:border-emerald-500 dark:bg-emerald-950/30'
                 : cvFile
                   ? 'border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-950/20'
-                  : 'border-gray-200 hover:border-teal-300 dark:border-gray-600 dark:hover:border-teal-600'"
+                  : 'border-gray-200 hover:border-emerald-300 dark:border-gray-600 dark:hover:border-emerald-600'"
               @dragover.prevent="dragOver = true"
               @dragleave.prevent="dragOver = false"
               @drop.prevent="handleDrop"
             >
               <div class="flex h-14 w-14 items-center justify-center rounded-xl"
-                :class="cvFile ? 'bg-green-100 dark:bg-green-900/40' : 'bg-teal-50 dark:bg-teal-950'">
+                :class="cvFile ? 'bg-green-100 dark:bg-green-900/40' : 'bg-emerald-50 dark:bg-emerald-950'">
                 <UIcon
                   :name="cvFile ? 'i-heroicons-document-check' : 'i-heroicons-document-arrow-up'"
                   class="h-7 w-7"
-                  :class="cvFile ? 'text-green-500' : 'text-teal-400'"
+                  :class="cvFile ? 'text-green-500' : 'text-emerald-400'"
                 />
               </div>
               <div class="text-center">
@@ -53,7 +53,7 @@
                   {{ cvFile.name }}
                 </p>
                 <p v-else class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Drop your CV here or <span class="text-teal-600 dark:text-teal-400">browse</span>
+                  Drop your CV here or <span class="text-emerald-600 dark:text-emerald-400">browse</span>
                 </p>
                 <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">PDF only · max 5 MB</p>
               </div>
@@ -94,9 +94,9 @@
             <!-- URL mode -->
             <template v-if="jobInputMode === 'url'">
               <div class="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3
-                          focus-within:border-teal-400 focus-within:bg-white focus-within:ring-2
-                          focus-within:ring-teal-200 dark:border-gray-700 dark:bg-gray-900
-                          dark:focus-within:border-teal-500 dark:focus-within:bg-gray-800">
+                          focus-within:border-emerald-400 focus-within:bg-white focus-within:ring-2
+                          focus-within:ring-emerald-200 dark:border-gray-700 dark:bg-gray-900
+                          dark:focus-within:border-emerald-500 dark:focus-within:bg-gray-800">
                 <UIcon name="i-heroicons-link" class="h-4 w-4 shrink-0 text-gray-400" />
                 <input
                   v-model="jobUrl"
@@ -122,9 +122,9 @@
                 placeholder="Paste the job description here…&#10;&#10;E.g. &quot;We are looking for a Senior Software Engineer with 5+ years of experience in Laravel, Vue.js, and AWS…&quot;"
                 class="w-full resize-none rounded-lg border border-gray-200 bg-gray-50 px-4 py-3
                        text-sm text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
+                       focus:border-emerald-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-emerald-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
+                       dark:focus:border-emerald-500 dark:focus:bg-gray-800"
               />
               <p class="mt-1.5 text-right text-xs text-gray-400">
                 {{ jobDescription.length }} / 5000 chars
@@ -136,7 +136,7 @@
         <!-- Analyse button -->
         <UButton
           size="lg"
-          color="teal"
+          color="emerald"
           block
           :loading="analysing"
           :disabled="!canAnalyse || analysing"
@@ -159,8 +159,8 @@
         <div v-if="!result && !analysing"
           class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200
                  bg-white py-20 text-center dark:border-gray-700 dark:bg-gray-800">
-          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
-            <UIcon name="i-heroicons-chart-bar-square" class="h-8 w-8 text-teal-300" />
+          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+            <UIcon name="i-heroicons-chart-bar-square" class="h-8 w-8 text-emerald-300" />
           </div>
           <p class="text-sm font-medium text-gray-400 dark:text-gray-500">Results will appear here</p>
           <p class="mt-1 text-xs text-gray-300 dark:text-gray-600">Upload your CV and add a job posting</p>
@@ -170,7 +170,7 @@
         <div v-else-if="analysing" class="flex flex-col gap-5">
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-6">
             <div class="flex flex-col items-center gap-4 py-6">
-              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-teal-400" />
+              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-emerald-400" />
               <div class="text-center">
                 <p class="text-sm font-semibold text-gray-900 dark:text-white">Analysing your CV…</p>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CODECV is reading your CV and comparing it to the job. This takes ~15 seconds.</p>
@@ -270,15 +270,15 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="border-b border-gray-100 px-5 py-4 dark:border-gray-700">
               <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-teal-500" />
+                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-emerald-500" />
                 How to Improve Your CV
               </h3>
             </div>
             <ul class="divide-y divide-gray-100 dark:divide-gray-700">
               <li v-for="(tip, i) in result.improvements" :key="tip"
                 class="flex items-start gap-3 px-5 py-3 text-sm text-gray-700 dark:text-gray-300">
-                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-50
-                             text-[10px] font-bold text-teal-600 dark:bg-teal-950 dark:text-teal-400">
+                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-50
+                             text-[10px] font-bold text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400">
                   {{ i + 1 }}
                 </span>
                 {{ tip }}

--- a/frontend/pages/my-cv.vue
+++ b/frontend/pages/my-cv.vue
@@ -9,7 +9,7 @@
           Upload your CV and provide a job posting — AI will score the match and suggest improvements.
         </p>
       </div>
-      <UBadge color="indigo" variant="subtle" size="sm" class="items-center gap-1.5">
+      <UBadge color="teal" variant="subtle" size="sm" class="items-center gap-1.5">
         <UIcon name="i-heroicons-sparkles" class="h-3.5 w-3.5" />
         Powered by CODECV
       </UBadge>
@@ -32,20 +32,20 @@
               class="flex cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed
                      px-6 py-10 transition-colors"
               :class="dragOver
-                ? 'border-indigo-400 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-950/30'
+                ? 'border-teal-400 bg-teal-50 dark:border-teal-500 dark:bg-teal-950/30'
                 : cvFile
                   ? 'border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-950/20'
-                  : 'border-gray-200 hover:border-indigo-300 dark:border-gray-600 dark:hover:border-indigo-600'"
+                  : 'border-gray-200 hover:border-teal-300 dark:border-gray-600 dark:hover:border-teal-600'"
               @dragover.prevent="dragOver = true"
               @dragleave.prevent="dragOver = false"
               @drop.prevent="handleDrop"
             >
               <div class="flex h-14 w-14 items-center justify-center rounded-xl"
-                :class="cvFile ? 'bg-green-100 dark:bg-green-900/40' : 'bg-indigo-50 dark:bg-indigo-950'">
+                :class="cvFile ? 'bg-green-100 dark:bg-green-900/40' : 'bg-teal-50 dark:bg-teal-950'">
                 <UIcon
                   :name="cvFile ? 'i-heroicons-document-check' : 'i-heroicons-document-arrow-up'"
                   class="h-7 w-7"
-                  :class="cvFile ? 'text-green-500' : 'text-indigo-400'"
+                  :class="cvFile ? 'text-green-500' : 'text-teal-400'"
                 />
               </div>
               <div class="text-center">
@@ -53,7 +53,7 @@
                   {{ cvFile.name }}
                 </p>
                 <p v-else class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Drop your CV here or <span class="text-indigo-600 dark:text-indigo-400">browse</span>
+                  Drop your CV here or <span class="text-teal-600 dark:text-teal-400">browse</span>
                 </p>
                 <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">PDF only · max 5 MB</p>
               </div>
@@ -94,9 +94,9 @@
             <!-- URL mode -->
             <template v-if="jobInputMode === 'url'">
               <div class="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3
-                          focus-within:border-indigo-400 focus-within:bg-white focus-within:ring-2
-                          focus-within:ring-indigo-200 dark:border-gray-700 dark:bg-gray-900
-                          dark:focus-within:border-indigo-500 dark:focus-within:bg-gray-800">
+                          focus-within:border-teal-400 focus-within:bg-white focus-within:ring-2
+                          focus-within:ring-teal-200 dark:border-gray-700 dark:bg-gray-900
+                          dark:focus-within:border-teal-500 dark:focus-within:bg-gray-800">
                 <UIcon name="i-heroicons-link" class="h-4 w-4 shrink-0 text-gray-400" />
                 <input
                   v-model="jobUrl"
@@ -122,9 +122,9 @@
                 placeholder="Paste the job description here…&#10;&#10;E.g. &quot;We are looking for a Senior Software Engineer with 5+ years of experience in Laravel, Vue.js, and AWS…&quot;"
                 class="w-full resize-none rounded-lg border border-gray-200 bg-gray-50 px-4 py-3
                        text-sm text-gray-700 placeholder-gray-400 transition-colors
-                       focus:border-indigo-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-indigo-200
+                       focus:border-teal-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-teal-200
                        dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:placeholder-gray-600
-                       dark:focus:border-indigo-500 dark:focus:bg-gray-800"
+                       dark:focus:border-teal-500 dark:focus:bg-gray-800"
               />
               <p class="mt-1.5 text-right text-xs text-gray-400">
                 {{ jobDescription.length }} / 5000 chars
@@ -136,7 +136,7 @@
         <!-- Analyse button -->
         <UButton
           size="lg"
-          color="indigo"
+          color="teal"
           block
           :loading="analysing"
           :disabled="!canAnalyse || analysing"
@@ -159,8 +159,8 @@
         <div v-if="!result && !analysing"
           class="flex flex-col items-center justify-center rounded-xl border border-dashed border-gray-200
                  bg-white py-20 text-center dark:border-gray-700 dark:bg-gray-800">
-          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950">
-            <UIcon name="i-heroicons-chart-bar-square" class="h-8 w-8 text-indigo-300" />
+          <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
+            <UIcon name="i-heroicons-chart-bar-square" class="h-8 w-8 text-teal-300" />
           </div>
           <p class="text-sm font-medium text-gray-400 dark:text-gray-500">Results will appear here</p>
           <p class="mt-1 text-xs text-gray-300 dark:text-gray-600">Upload your CV and add a job posting</p>
@@ -170,7 +170,7 @@
         <div v-else-if="analysing" class="flex flex-col gap-5">
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800 p-6">
             <div class="flex flex-col items-center gap-4 py-6">
-              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-indigo-400" />
+              <UIcon name="i-heroicons-sparkles" class="h-10 w-10 animate-pulse text-teal-400" />
               <div class="text-center">
                 <p class="text-sm font-semibold text-gray-900 dark:text-white">Analysing your CV…</p>
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CODECV is reading your CV and comparing it to the job. This takes ~15 seconds.</p>
@@ -270,15 +270,15 @@
           <div class="rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
             <div class="border-b border-gray-100 px-5 py-4 dark:border-gray-700">
               <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
-                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-indigo-500" />
+                <UIcon name="i-heroicons-light-bulb" class="h-4 w-4 text-teal-500" />
                 How to Improve Your CV
               </h3>
             </div>
             <ul class="divide-y divide-gray-100 dark:divide-gray-700">
               <li v-for="(tip, i) in result.improvements" :key="tip"
                 class="flex items-start gap-3 px-5 py-3 text-sm text-gray-700 dark:text-gray-300">
-                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-indigo-50
-                             text-[10px] font-bold text-indigo-600 dark:bg-indigo-950 dark:text-indigo-400">
+                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-teal-50
+                             text-[10px] font-bold text-teal-600 dark:bg-teal-950 dark:text-teal-400">
                   {{ i + 1 }}
                 </span>
                 {{ tip }}

--- a/frontend/pages/my-paths.vue
+++ b/frontend/pages/my-paths.vue
@@ -12,7 +12,7 @@
       <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
         <button
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-          :class="view === 'timeline' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+          :class="view === 'timeline' ? 'bg-emerald-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
           @click="view = 'timeline'"
         >
           <UIcon name="i-heroicons-bars-3-bottom-left" class="h-3.5 w-3.5" />
@@ -20,7 +20,7 @@
         </button>
         <button
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-          :class="view === 'roadmap' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+          :class="view === 'roadmap' ? 'bg-emerald-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
           @click="view = 'roadmap'"
         >
           <UIcon name="i-heroicons-map" class="h-3.5 w-3.5" />
@@ -31,15 +31,15 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-20">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
     </div>
 
     <template v-else>
 
       <!-- Empty -->
       <div v-if="!paths.length" class="flex flex-col items-center py-20 text-center">
-        <div class="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
-          <UIcon name="i-heroicons-map" class="h-10 w-10 text-teal-400" />
+        <div class="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+          <UIcon name="i-heroicons-map" class="h-10 w-10 text-emerald-400" />
         </div>
         <h3 class="text-base font-semibold text-gray-900 dark:text-white">No learning paths yet</h3>
         <p class="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
@@ -47,7 +47,7 @@
         </p>
         <a href="https://wa.me/353894050730?text=Hi%2C+I%27d+like+to+get+a+learning+path+assigned+to+my+profile."
           target="_blank"
-          class="mt-5 inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2.5
+          class="mt-5 inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2.5
                  text-sm font-semibold text-white transition-opacity hover:opacity-90">
           <UIcon name="i-heroicons-chat-bubble-left-ellipsis" class="h-4 w-4" />
           Request a Learning Path
@@ -533,7 +533,7 @@ async function setStatus(path: any, step: PathStep, status: PathStep['user_statu
 
 function statusBadgeColor(status: PathStep['user_status']) {
   if (status === 'done') return 'green'
-  if (status === 'in_progress') return 'teal'
+  if (status === 'in_progress') return 'emerald'
   return 'gray'
 }
 
@@ -545,7 +545,7 @@ function statusLabel(status: PathStep['user_status']) {
 
 function progressColor(pct: number) {
   if (pct >= 75) return 'text-green-600 dark:text-green-400'
-  if (pct >= 40) return 'text-teal-600 dark:text-teal-400'
+  if (pct >= 40) return 'text-emerald-600 dark:text-emerald-400'
   return 'text-gray-500 dark:text-gray-400'
 }
 
@@ -587,7 +587,7 @@ const statusOptions = [
   { value: 'not_started' as const, label: 'Not Started', icon: 'i-heroicons-minus-circle',
     activeClass: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' },
   { value: 'in_progress' as const, label: 'In Progress', icon: 'i-heroicons-play-circle',
-    activeClass: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300' },
+    activeClass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' },
   { value: 'done' as const, label: 'Done', icon: 'i-heroicons-check-circle',
     activeClass: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' },
 ]

--- a/frontend/pages/my-paths.vue
+++ b/frontend/pages/my-paths.vue
@@ -12,7 +12,7 @@
       <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
         <button
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-          :class="view === 'timeline' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+          :class="view === 'timeline' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
           @click="view = 'timeline'"
         >
           <UIcon name="i-heroicons-bars-3-bottom-left" class="h-3.5 w-3.5" />
@@ -20,7 +20,7 @@
         </button>
         <button
           class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-          :class="view === 'roadmap' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+          :class="view === 'roadmap' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
           @click="view = 'roadmap'"
         >
           <UIcon name="i-heroicons-map" class="h-3.5 w-3.5" />
@@ -31,15 +31,15 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-20">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-indigo-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
     </div>
 
     <template v-else>
 
       <!-- Empty -->
       <div v-if="!paths.length" class="flex flex-col items-center py-20 text-center">
-        <div class="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950">
-          <UIcon name="i-heroicons-map" class="h-10 w-10 text-indigo-400" />
+        <div class="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
+          <UIcon name="i-heroicons-map" class="h-10 w-10 text-teal-400" />
         </div>
         <h3 class="text-base font-semibold text-gray-900 dark:text-white">No learning paths yet</h3>
         <p class="mt-2 max-w-sm text-sm text-gray-500 dark:text-gray-400">
@@ -47,7 +47,7 @@
         </p>
         <a href="https://wa.me/353894050730?text=Hi%2C+I%27d+like+to+get+a+learning+path+assigned+to+my+profile."
           target="_blank"
-          class="mt-5 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2.5
+          class="mt-5 inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2.5
                  text-sm font-semibold text-white transition-opacity hover:opacity-90">
           <UIcon name="i-heroicons-chat-bubble-left-ellipsis" class="h-4 w-4" />
           Request a Learning Path
@@ -59,26 +59,32 @@
         <div v-for="path in enrichedPaths" :key="path.id">
 
           <!-- Path header card -->
-          <div class="mb-4 rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-            <div class="flex flex-wrap items-center gap-4 p-5">
-              <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-indigo-50 dark:bg-indigo-950">
-                <UIcon name="i-heroicons-map" class="h-6 w-6 text-indigo-500" />
+          <div class="mb-4 overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+            <div class="flex flex-wrap items-start gap-4 p-5">
+              <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-950">
+                <UIcon name="i-heroicons-map" class="h-6 w-6 text-emerald-500" />
               </div>
               <div class="min-w-0 flex-1">
                 <h2 class="text-base font-bold text-gray-900 dark:text-white">{{ path.name }}</h2>
-                <p v-if="path.description" class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                <p v-if="path.description" class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
                   {{ path.description }}
                 </p>
+                <!-- This path includes -->
+                <div class="mt-3 grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-3">
+                  <div v-for="item in pathIncludes(path)" :key="item.label"
+                    class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                    <UIcon :name="item.icon" class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+                    {{ item.label }}
+                  </div>
+                </div>
               </div>
-              <!-- Overall progress -->
-              <div class="flex shrink-0 flex-col items-end gap-1">
-                <span class="text-sm font-bold" :class="progressColor(path.progressPct)">
+              <!-- Progress -->
+              <div class="flex shrink-0 flex-col items-end gap-1.5">
+                <span class="text-lg font-black" :class="progressColor(path.progressPct)">
                   {{ path.progressPct }}%
                 </span>
-                <UProgress :value="path.progressPct" size="sm" color="indigo" class="w-32" />
-                <span class="text-xs text-gray-400">
-                  {{ path.doneCount }} / {{ path.steps.length }} done
-                </span>
+                <UProgress :value="path.progressPct" size="sm" color="emerald" class="w-28" />
+                <span class="text-xs text-gray-400">{{ path.doneCount }} / {{ path.steps.length }} done</span>
               </div>
             </div>
           </div>
@@ -87,96 +93,163 @@
           <RoadmapFlow
             v-if="view === 'roadmap' && path.steps.length"
             :steps="path.steps"
-            @node-click="(step) => toggleExpanded(step.id)"
+            @node-click="(step) => openStepModal(step, path)"
           />
 
-          <!-- Timeline -->
-          <div v-if="view === 'timeline' && path.steps.length" class="flex flex-col pl-2 sm:pl-6">
-            <div v-for="(step, i) in path.steps" :key="step.id" class="flex gap-4">
+          <!-- Course content (Udemy-style accordion) -->
+          <div v-if="view === 'timeline' && path.steps.length">
 
-              <!-- Connector -->
-              <div class="flex flex-col items-center">
-                <!-- Node -->
+            <!-- Summary bar -->
+            <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+              {{ path.steps.length }} steps
+              <span class="mx-1">·</span>
+              {{ path.doneCount }} completed
+              <span v-if="resourceTotal(path) > 0">
+                <span class="mx-1">·</span>{{ resourceTotal(path) }} resources
+              </span>
+            </p>
+
+            <!-- Accordion -->
+            <div class="overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+              <div v-for="(step, i) in path.steps" :key="step.id"
+                class="border-b border-gray-100 last:border-b-0 dark:border-gray-700/60">
+
+                <!-- Row header -->
                 <button
-                  class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 font-bold text-xs
-                         transition-all focus:outline-none"
-                  :class="nodeClass(step.user_status)"
-                  :title="statusLabel(step.user_status)"
-                  @click="cycleStatus(path, step)"
+                  class="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors
+                         hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  :class="expanded.has(step.id) ? 'bg-gray-50 dark:bg-gray-800/40' : 'bg-white dark:bg-gray-900'"
+                  @click="toggleExpanded(step.id)"
                 >
-                  <UIcon v-if="step.user_status === 'done'" name="i-heroicons-check" class="h-4 w-4" />
-                  <span v-else>{{ i + 1 }}</span>
-                </button>
-                <!-- Line -->
-                <div v-if="i < path.steps.length - 1"
-                  class="my-1 w-0.5 flex-1"
-                  :class="step.user_status === 'done' ? 'bg-green-300 dark:bg-green-700' : 'bg-gray-200 dark:bg-gray-700'"
-                />
-              </div>
+                  <!-- Done/number indicator -->
+                  <div class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold"
+                    :class="step.user_status === 'done'
+                      ? 'bg-emerald-500 text-white'
+                      : step.user_status === 'in_progress'
+                        ? 'bg-blue-500 text-white'
+                        : 'border-2 border-gray-300 text-gray-400 dark:border-gray-600'">
+                    <UIcon v-if="step.user_status === 'done'" name="i-heroicons-check" class="h-3 w-3" />
+                    <span v-else>{{ i + 1 }}</span>
+                  </div>
 
-              <!-- Step card -->
-              <div class="mb-3 min-w-0 flex-1 cursor-pointer rounded-xl border transition-all"
-                :class="stepCardClass(step.user_status)"
-                @click="toggleExpanded(step.id)">
-                <div class="flex items-start gap-3 p-4">
+                  <!-- Type icon -->
+                  <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gray-100 dark:bg-gray-800">
+                    <UIcon :name="stepTypeIcon(step.type)" class="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
+                  </div>
+
+                  <!-- Title + sub-label -->
                   <div class="min-w-0 flex-1">
-                    <div class="flex flex-wrap items-center gap-2">
-                      <p class="text-sm font-semibold"
-                        :class="step.user_status === 'done'
-                          ? 'text-gray-400 line-through dark:text-gray-500'
-                          : 'text-gray-900 dark:text-white'">
-                        {{ step.title }}
-                      </p>
-                      <UBadge :color="statusBadgeColor(step.user_status)" variant="subtle" size="xs">
-                        {{ statusLabel(step.user_status) }}
-                      </UBadge>
-                    </div>
-                    <!-- Expanded content -->
-                    <Transition enter-from-class="opacity-0 -translate-y-1" enter-active-class="transition duration-150"
-                                leave-to-class="opacity-0 -translate-y-1" leave-active-class="transition duration-100">
-                      <div v-if="expanded.has(step.id)" class="mt-3">
-                        <p v-if="step.description" class="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
-                          {{ step.description }}
-                        </p>
-                        <!-- Linked course -->
-                        <div v-if="step.course" class="mt-3">
-                          <UButton size="xs" color="indigo" variant="soft" icon="i-heroicons-book-open"
-                            @click.stop="navigateTo(`/courses/${step.course!.id}`)">
-                            Open Course: {{ step.course.name }}
-                          </UButton>
-                        </div>
-                        <!-- Resources -->
-                        <div v-if="step.resources?.length" class="mt-3 flex flex-wrap gap-2">
+                    <p class="text-sm font-medium leading-snug"
+                      :class="step.user_status === 'done'
+                        ? 'text-gray-400 line-through dark:text-gray-500'
+                        : 'text-gray-900 dark:text-white'">
+                      {{ step.title }}
+                    </p>
+                    <p class="mt-0.5 text-[11px] text-gray-400 dark:text-gray-500">
+                      {{ stepTypeLabel(step.type) }}
+                      <span v-if="step.resources?.length"> · {{ step.resources.length }} resource{{ step.resources.length !== 1 ? 's' : '' }}</span>
+                    </p>
+                  </div>
+
+                  <!-- Status badge -->
+                  <UBadge :color="statusBadgeColor(step.user_status)" variant="subtle" size="xs" class="shrink-0">
+                    {{ statusLabel(step.user_status) }}
+                  </UBadge>
+
+                  <UIcon :name="expanded.has(step.id) ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'"
+                    class="h-4 w-4 shrink-0 text-gray-400" />
+                </button>
+
+                <!-- Expanded drawer -->
+                <Transition
+                  enter-from-class="opacity-0 -translate-y-1" enter-active-class="transition duration-150"
+                  leave-to-class="opacity-0 -translate-y-1"   leave-active-class="transition duration-100">
+                  <div v-if="expanded.has(step.id)"
+                    class="border-t border-gray-100 bg-gray-50/60 px-5 py-4 dark:border-gray-700/60 dark:bg-gray-800/30">
+
+                    <div class="space-y-4">
+
+                      <!-- Overview -->
+                      <div v-if="step.description">
+                        <p class="mb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Overview</p>
+                        <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-300">{{ step.description }}</p>
+                      </div>
+
+                      <!-- What you'll learn -->
+                      <div v-if="step.instructions?.length">
+                        <p class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">What you'll learn</p>
+                        <ul class="space-y-1.5">
+                          <li v-for="ins in step.instructions" :key="ins.id"
+                            class="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                            <UIcon name="i-heroicons-check-circle" class="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+                            {{ ins.text }}
+                          </li>
+                        </ul>
+                      </div>
+
+                      <!-- Challenge prompt -->
+                      <div v-if="step.challenge_prompt">
+                        <p class="mb-1 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Challenge</p>
+                        <blockquote class="border-l-2 border-emerald-400 pl-3 text-sm italic leading-relaxed text-gray-600 dark:text-gray-400">
+                          {{ step.challenge_prompt }}
+                        </blockquote>
+                      </div>
+
+                      <!-- Linked course -->
+                      <div v-if="step.course">
+                        <button
+                          class="flex w-full items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-left
+                                 transition-colors hover:bg-emerald-100 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:hover:bg-emerald-950/50"
+                          @click.stop="navigateTo(`/courses/${step.course!.id}`)">
+                          <UIcon name="i-heroicons-book-open" class="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+                          <div>
+                            <p class="text-sm font-semibold text-emerald-700 dark:text-emerald-300">{{ step.course.name }}</p>
+                            <p class="text-xs text-emerald-600/70 dark:text-emerald-400/60">Open course material →</p>
+                          </div>
+                        </button>
+                      </div>
+
+                      <!-- Lab / Challenge CTA -->
+                      <div v-if="step.type === 'lab' || step.type === 'challenge'">
+                        <UButton size="sm" color="emerald" variant="solid" :icon="stepTypeIcon(step.type)"
+                          @click.stop="navigateTo(`/labs/${step.id}`)">
+                          {{ step.type === 'lab' ? 'Open Lab Environment' : 'Start Challenge' }}
+                        </UButton>
+                      </div>
+
+                      <!-- Resources -->
+                      <div v-if="step.resources?.length">
+                        <p class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Resources</p>
+                        <div class="flex flex-wrap gap-2">
                           <a v-for="r in step.resources" :key="r.url"
                             :href="r.url" target="_blank"
-                            class="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1
-                                   text-xs font-medium text-gray-600 hover:bg-indigo-50 hover:text-indigo-600
-                                   dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-indigo-950 dark:hover:text-indigo-400"
+                            class="flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium
+                                   text-gray-600 transition-colors hover:border-emerald-300 hover:bg-emerald-50 hover:text-emerald-700
+                                   dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-emerald-700 dark:hover:text-emerald-400"
                             @click.stop>
                             <UIcon name="i-heroicons-arrow-top-right-on-square" class="h-3 w-3" />
                             {{ r.label }}
                           </a>
                         </div>
-                        <!-- Status controls -->
-                        <div class="mt-4 flex flex-wrap gap-2">
-                          <button v-for="s in statusOptions" :key="s.value"
-                            class="flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition-colors"
-                            :class="step.user_status === s.value
-                              ? `border-transparent ${s.activeClass}`
-                              : 'border-gray-200 text-gray-500 hover:border-gray-300 dark:border-gray-600'"
-                            @click.stop="setStatus(path, step, s.value)">
-                            <UIcon :name="s.icon" class="h-3.5 w-3.5" />
-                            {{ s.label }}
-                          </button>
-                        </div>
                       </div>
-                    </Transition>
+
+                      <!-- Status controls -->
+                      <div class="flex flex-wrap gap-2 border-t border-gray-100 pt-3 dark:border-gray-700/60">
+                        <button v-for="s in statusOptions" :key="s.value"
+                          class="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
+                          :class="step.user_status === s.value
+                            ? `border-transparent ${s.activeClass}`
+                            : 'border-gray-200 text-gray-500 hover:border-gray-300 dark:border-gray-600 dark:text-gray-400'"
+                          @click.stop="setStatus(path, step, s.value)">
+                          <UIcon :name="s.icon" class="h-3.5 w-3.5" />
+                          {{ s.label }}
+                        </button>
+                      </div>
+
+                    </div>
                   </div>
-                  <UIcon
-                    :name="expanded.has(step.id) ? 'i-heroicons-chevron-up' : 'i-heroicons-chevron-down'"
-                    class="h-4 w-4 shrink-0 text-gray-400"
-                  />
-                </div>
+                </Transition>
+
               </div>
             </div>
           </div>
@@ -189,6 +262,152 @@
       </div>
 
     </template>
+  <!-- Blocking modal: step order enforcement -->
+  <UModal v-model="showBlockModal">
+    <UCard :ui="{ ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-700' }">
+      <template #header>
+        <div class="flex items-center gap-3">
+          <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-950/60">
+            <UIcon name="i-heroicons-lock-closed" class="h-5 w-5 text-amber-500" />
+          </div>
+          <p class="font-semibold text-gray-900 dark:text-white">Finish your current step first</p>
+        </div>
+      </template>
+
+      <p class="py-1 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+        You're still working on
+        <strong class="text-gray-900 dark:text-white">"{{ blockedByStep?.title }}"</strong>.
+        Mark it as <strong>Done</strong> before starting a new step — this keeps your focus sharp and your roadmap clean.
+      </p>
+
+      <template #footer>
+        <div class="flex justify-end">
+          <UButton color="emerald" @click="showBlockModal = false">Got it</UButton>
+        </div>
+      </template>
+    </UCard>
+  </UModal>
+
+  <!-- Step detail modal (roadmap click) -->
+  <UModal v-model="showStepModal" :ui="{ width: 'sm:max-w-xl' }">
+    <UCard v-if="modalStep" :ui="{ ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-700', body: { padding: 'p-0' } }">
+
+      <!-- Coloured header band -->
+      <template #header>
+        <div class="flex flex-wrap items-start gap-3">
+          <!-- Step number / status dot -->
+          <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold"
+            :class="modalStep.user_status === 'done'
+              ? 'bg-emerald-600 text-white'
+              : modalStep.user_status === 'in_progress'
+                ? 'bg-blue-500 text-white'
+                : 'border-2 border-gray-300 bg-white text-gray-500 dark:border-gray-600 dark:bg-gray-800'">
+            <UIcon v-if="modalStep.user_status === 'done'" name="i-heroicons-check" class="h-4 w-4" />
+            <span v-else>{{ modalStep.order }}</span>
+          </div>
+          <div class="min-w-0 flex-1">
+            <p class="text-base font-bold text-gray-900 dark:text-white leading-tight">{{ modalStep.title }}</p>
+            <!-- type pill -->
+            <div class="mt-1 flex items-center gap-1.5">
+              <UIcon :name="stepTypeIcon(modalStep.type)" class="h-3.5 w-3.5 text-emerald-500" />
+              <span class="text-xs font-medium text-emerald-600 dark:text-emerald-400 capitalize">{{ stepTypeLabel(modalStep.type) }}</span>
+            </div>
+          </div>
+          <UBadge :color="statusBadgeColor(modalStep.user_status)" variant="subtle" size="sm">
+            {{ statusLabel(modalStep.user_status) }}
+          </UBadge>
+        </div>
+      </template>
+
+      <!-- Body -->
+      <div class="space-y-5 px-5 py-4">
+
+        <!-- Description -->
+        <div v-if="modalStep.description">
+          <p class="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Overview</p>
+          <p class="text-sm leading-relaxed text-gray-700 dark:text-gray-300">{{ modalStep.description }}</p>
+        </div>
+
+        <!-- What you'll learn (instructions) -->
+        <div v-if="modalStep.instructions?.length">
+          <p class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">What you'll learn</p>
+          <ul class="space-y-2">
+            <li v-for="ins in modalStep.instructions" :key="ins.id"
+              class="flex items-start gap-2.5 text-sm text-gray-700 dark:text-gray-300">
+              <UIcon name="i-heroicons-check-circle" class="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+              {{ ins.text }}
+            </li>
+          </ul>
+        </div>
+
+        <!-- Challenge prompt -->
+        <div v-if="modalStep.challenge_prompt">
+          <p class="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Challenge</p>
+          <blockquote class="border-l-2 border-emerald-400 pl-3 text-sm italic leading-relaxed text-gray-600 dark:text-gray-400">
+            {{ modalStep.challenge_prompt }}
+          </blockquote>
+        </div>
+
+        <!-- Linked course -->
+        <div v-if="modalStep.course">
+          <p class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Linked Course</p>
+          <button
+            class="flex w-full items-center gap-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3
+                   text-left transition-colors hover:bg-emerald-100 dark:border-emerald-900/50 dark:bg-emerald-950/30 dark:hover:bg-emerald-950/50"
+            @click="navigateTo(`/courses/${modalStep.course!.id}`)">
+            <UIcon name="i-heroicons-book-open" class="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            <div class="min-w-0 flex-1">
+              <p class="text-sm font-semibold text-emerald-700 dark:text-emerald-300">{{ modalStep.course.name }}</p>
+              <p class="text-xs text-emerald-600/70 dark:text-emerald-400/70">Open course material →</p>
+            </div>
+          </button>
+        </div>
+
+        <!-- Lab / Challenge CTA -->
+        <div v-if="modalStep.type === 'lab' || modalStep.type === 'challenge'">
+          <UButton size="sm" color="emerald" variant="solid" :icon="stepTypeIcon(modalStep.type)"
+            @click="navigateTo(`/labs/${modalStep.id}`)">
+            {{ modalStep.type === 'lab' ? 'Open Lab Environment' : 'Start Challenge' }}
+          </UButton>
+        </div>
+
+        <!-- Resources -->
+        <div v-if="modalStep.resources?.length">
+          <p class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">Resources</p>
+          <div class="flex flex-wrap gap-2">
+            <a v-for="r in modalStep.resources" :key="r.url"
+              :href="r.url" target="_blank"
+              class="flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium
+                     text-gray-600 transition-colors hover:border-emerald-300 hover:bg-emerald-50 hover:text-emerald-700
+                     dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:border-emerald-700 dark:hover:text-emerald-400">
+              <UIcon name="i-heroicons-arrow-top-right-on-square" class="h-3 w-3" />
+              {{ r.label }}
+            </a>
+          </div>
+        </div>
+
+      </div>
+
+      <template #footer>
+        <!-- Status controls -->
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <div class="flex flex-wrap gap-2">
+            <button v-for="s in statusOptions" :key="s.value"
+              class="flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors"
+              :class="modalStep.user_status === s.value
+                ? `border-transparent ${s.activeClass}`
+                : 'border-gray-200 text-gray-500 hover:border-gray-300 dark:border-gray-600 dark:text-gray-400'"
+              @click="setStatusModal(s.value)">
+              <UIcon :name="s.icon" class="h-3.5 w-3.5" />
+              {{ s.label }}
+            </button>
+          </div>
+          <UButton color="gray" variant="ghost" size="sm" @click="showStepModal = false">Close</UButton>
+        </div>
+      </template>
+    </UCard>
+  </UModal>
+
   </NuxtLayout>
 </template>
 
@@ -206,6 +425,30 @@ const view = ref<'timeline' | 'roadmap'>('timeline')
 const pathSteps = ref<Record<number, PathStep[]>>({})
 const expanded  = ref(new Set<number>())
 const saving    = ref(new Set<number>())
+
+// Step order blocking modal
+const showBlockModal  = ref(false)
+const blockedByStep   = ref<PathStep | null>(null)
+
+// Step detail modal (roadmap view)
+const showStepModal = ref(false)
+const modalStep     = ref<PathStep | null>(null)
+const modalPath     = ref<any | null>(null)
+
+function openStepModal(step: any, path: any) {
+  modalStep.value = step
+  modalPath.value = path
+  showStepModal.value = true
+}
+
+async function setStatusModal(status: PathStep['user_status']) {
+  if (!modalPath.value || !modalStep.value) return
+  const step = modalStep.value
+  await setStatus(modalPath.value, step, status)
+  // sync modal display
+  const updated = pathSteps.value[modalPath.value.id]?.find(s => s.id === step.id)
+  if (updated) modalStep.value = updated
+}
 
 onMounted(async () => {
   const all = await fetchMyPaths()
@@ -245,12 +488,31 @@ async function cycleStatus(path: any, step: PathStep) {
 }
 
 async function setStatus(path: any, step: PathStep, status: PathStep['user_status']) {
+  if (status === 'in_progress') {
+    const arr = pathSteps.value[path.id] ?? []
+    const blocker = arr.find(s => s.order < step.order && s.user_status === 'in_progress')
+    if (blocker) {
+      blockedByStep.value = blocker
+      showBlockModal.value = true
+      return
+    }
+  }
+
   if (saving.value.has(step.id)) return
   saving.value.add(step.id)
 
-  const prev = step.user_status
-  // optimistic update
   const arr = pathSteps.value[path.id]
+
+  // snapshot for rollback
+  const snapshot = arr ? arr.map(s => ({ ...s })) : []
+
+  // optimistic: demote any other in_progress sibling
+  if (status === 'in_progress' && arr) {
+    arr.forEach((s, i) => {
+      if (s.id !== step.id && s.user_status === 'in_progress') arr[i] = { ...s, user_status: 'not_started' }
+    })
+  }
+  // optimistic: update this step
   if (arr) {
     const idx = arr.findIndex(s => s.id === step.id)
     if (idx !== -1) arr[idx] = { ...arr[idx], user_status: status }
@@ -259,11 +521,8 @@ async function setStatus(path: any, step: PathStep, status: PathStep['user_statu
   try {
     await updateStepProgress(step.id, status)
   } catch {
-    // rollback
-    if (arr) {
-      const idx = arr.findIndex(s => s.id === step.id)
-      if (idx !== -1) arr[idx] = { ...arr[idx], user_status: prev }
-    }
+    // rollback all changes
+    if (arr) pathSteps.value[path.id] = snapshot
     toast.add({ title: 'Could not save progress', color: 'red' })
   } finally {
     saving.value.delete(step.id)
@@ -272,23 +531,9 @@ async function setStatus(path: any, step: PathStep, status: PathStep['user_statu
 
 // ── Styling helpers ─────────────────────────────────────
 
-function nodeClass(status: PathStep['user_status']) {
-  if (status === 'done')        return 'border-green-400 bg-green-500 text-white dark:border-green-500'
-  if (status === 'in_progress') return 'border-indigo-400 bg-indigo-500 text-white dark:border-indigo-500'
-  return 'border-gray-300 bg-white text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400'
-}
-
-function stepCardClass(status: PathStep['user_status']) {
-  if (status === 'done')
-    return 'border-green-100 bg-green-50/50 dark:border-green-900/30 dark:bg-green-950/10'
-  if (status === 'in_progress')
-    return 'border-indigo-200 bg-indigo-50/50 dark:border-indigo-800/40 dark:bg-indigo-950/20'
-  return 'border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800'
-}
-
 function statusBadgeColor(status: PathStep['user_status']) {
   if (status === 'done') return 'green'
-  if (status === 'in_progress') return 'indigo'
+  if (status === 'in_progress') return 'teal'
   return 'gray'
 }
 
@@ -300,15 +545,49 @@ function statusLabel(status: PathStep['user_status']) {
 
 function progressColor(pct: number) {
   if (pct >= 75) return 'text-green-600 dark:text-green-400'
-  if (pct >= 40) return 'text-indigo-600 dark:text-indigo-400'
+  if (pct >= 40) return 'text-teal-600 dark:text-teal-400'
   return 'text-gray-500 dark:text-gray-400'
+}
+
+function pathIncludes(path: any) {
+  const steps: any[] = path.steps ?? []
+  const items = []
+  const reading   = steps.filter(s => !s.type || s.type === 'reading').length
+  const labs      = steps.filter(s => s.type === 'lab').length
+  const challenges = steps.filter(s => s.type === 'challenge').length
+  const quizzes   = steps.filter(s => s.type === 'quiz').length
+  const resources = steps.reduce((n: number, s: any) => n + (s.resources?.length ?? 0), 0)
+  if (reading)    items.push({ icon: 'i-heroicons-book-open',      label: `${reading} reading step${reading !== 1 ? 's' : ''}` })
+  if (labs)       items.push({ icon: 'i-heroicons-command-line',   label: `${labs} hands-on lab${labs !== 1 ? 's' : ''}` })
+  if (challenges) items.push({ icon: 'i-heroicons-trophy',         label: `${challenges} challenge${challenges !== 1 ? 's' : ''}` })
+  if (quizzes)    items.push({ icon: 'i-heroicons-question-mark-circle', label: `${quizzes} quiz${quizzes !== 1 ? 'zes' : ''}` })
+  if (resources)  items.push({ icon: 'i-heroicons-link',           label: `${resources} resource${resources !== 1 ? 's' : ''}` })
+  return items
+}
+
+function resourceTotal(path: any) {
+  return (path.steps ?? []).reduce((n: number, s: any) => n + (s.resources?.length ?? 0), 0)
+}
+
+function stepTypeIcon(type?: string) {
+  if (type === 'lab')       return 'i-heroicons-command-line'
+  if (type === 'challenge') return 'i-heroicons-trophy'
+  if (type === 'quiz')      return 'i-heroicons-question-mark-circle'
+  return 'i-heroicons-book-open'
+}
+
+function stepTypeLabel(type?: string) {
+  if (type === 'lab')       return 'Hands-on Lab'
+  if (type === 'challenge') return 'Challenge'
+  if (type === 'quiz')      return 'Quiz'
+  return 'Reading'
 }
 
 const statusOptions = [
   { value: 'not_started' as const, label: 'Not Started', icon: 'i-heroicons-minus-circle',
     activeClass: 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' },
   { value: 'in_progress' as const, label: 'In Progress', icon: 'i-heroicons-play-circle',
-    activeClass: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300' },
+    activeClass: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300' },
   { value: 'done' as const, label: 'Done', icon: 'i-heroicons-check-circle',
     activeClass: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300' },
 ]

--- a/frontend/pages/paths/[id].vue
+++ b/frontend/pages/paths/[id].vue
@@ -3,7 +3,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-24">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-indigo-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
     </div>
 
     <template v-else-if="currentPath">
@@ -24,20 +24,20 @@
           <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-              :class="view === 'timeline' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+              :class="view === 'timeline' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
               @click="view = 'timeline'"
             >
               <UIcon name="i-heroicons-bars-3-bottom-left" class="h-3.5 w-3.5" /> Timeline
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-              :class="view === 'roadmap' ? 'bg-indigo-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+              :class="view === 'roadmap' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
               @click="view = 'roadmap'"
             >
               <UIcon name="i-heroicons-map" class="h-3.5 w-3.5" /> Roadmap
             </button>
           </div>
-          <UButton icon="i-heroicons-plus" size="sm" color="indigo" @click="openAddStep">
+          <UButton icon="i-heroicons-plus" size="sm" color="teal" @click="openAddStep">
             Add Step
           </UButton>
         </div>
@@ -80,16 +80,24 @@
 
               <!-- Card -->
               <div class="mb-4 flex-1 rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-                :class="{ 'ring-2 ring-indigo-200 dark:ring-indigo-800': editingStep?.id === step.id }">
+                :class="{ 'ring-2 ring-teal-200 dark:ring-teal-800': editingStep?.id === step.id }">
                 <div class="flex items-start justify-between gap-3 p-4">
                   <div class="min-w-0 flex-1">
                     <p class="font-semibold text-gray-900 dark:text-white">{{ step.title }}</p>
                     <p v-if="step.description" class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
                       {{ step.description }}
                     </p>
-                    <!-- Linked course -->
-                    <div v-if="step.course" class="mt-2 flex items-center gap-2">
-                      <UBadge color="indigo" variant="subtle" size="xs" icon="i-heroicons-book-open">
+                    <!-- Type badge + Open Lab -->
+                    <div class="mt-2 flex flex-wrap items-center gap-2">
+                      <UBadge v-if="step.type && step.type !== 'reading'" :color="stepTypeBadgeColor(step.type)" variant="subtle" size="xs">
+                        {{ stepTypeLabel(step.type) }}
+                      </UBadge>
+                      <UButton v-if="step.type === 'lab' || step.type === 'challenge'"
+                        size="xs" color="teal" variant="soft" icon="i-heroicons-command-line"
+                        @click.stop="navigateTo(`/labs/${step.id}`)">
+                        Open Lab
+                      </UButton>
+                      <UBadge v-if="step.course" color="teal" variant="subtle" size="xs" icon="i-heroicons-book-open">
                         {{ step.course.name }}
                       </UBadge>
                     </div>
@@ -97,7 +105,7 @@
                     <div v-if="step.resources?.length" class="mt-2 flex flex-wrap gap-2">
                       <a v-for="r in step.resources" :key="r.url"
                         :href="r.url" target="_blank"
-                        class="flex items-center gap-1 text-xs text-indigo-600 hover:underline dark:text-indigo-400">
+                        class="flex items-center gap-1 text-xs text-teal-600 hover:underline dark:text-teal-400">
                         <UIcon name="i-heroicons-link" class="h-3 w-3" />
                         {{ r.label }}
                       </a>
@@ -151,9 +159,9 @@
           </div>
 
           <!-- Tip -->
-          <div class="rounded-xl bg-indigo-50 p-4 dark:bg-indigo-950/30">
-            <p class="text-xs font-semibold text-indigo-700 dark:text-indigo-400">Tip</p>
-            <p class="mt-1 text-xs text-indigo-600 dark:text-indigo-500 leading-relaxed">
+          <div class="rounded-xl bg-teal-50 p-4 dark:bg-teal-950/30">
+            <p class="text-xs font-semibold text-teal-700 dark:text-teal-400">Tip</p>
+            <p class="mt-1 text-xs text-teal-600 dark:text-teal-500 leading-relaxed">
               Use the ↑ ↓ arrows to reorder steps. Link a course to each step so clients can access content directly from their roadmap.
             </p>
           </div>
@@ -180,17 +188,65 @@
         />
 
         <div class="flex flex-col gap-4">
-          <!-- Title -->
-          <div>
-            <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">Title *</label>
-            <UInput v-model="form.title" placeholder="e.g. Learn Git & GitHub" />
+          <!-- Title + Type row -->
+          <div class="flex gap-3">
+            <div class="flex-1">
+              <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">Title *</label>
+              <UInput v-model="form.title" placeholder="e.g. Instrument your Node.js app" />
+            </div>
+            <div class="w-36 shrink-0">
+              <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">Type</label>
+              <USelect v-model="form.type"
+                :options="[
+                  { label: '📖 Reading', value: 'reading' },
+                  { label: '🧪 Lab', value: 'lab' },
+                  { label: '🎯 Challenge', value: 'challenge' },
+                  { label: '❓ Quiz', value: 'quiz' },
+                ]"
+                value-attribute="value" option-attribute="label" />
+            </div>
           </div>
 
           <!-- Description -->
           <div>
             <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">Description</label>
-            <UTextarea v-model="form.description" :rows="3"
+            <UTextarea v-model="form.description" :rows="2"
               placeholder="What will the student learn or do in this step?" />
+          </div>
+
+          <!-- Lab URL (only for lab/challenge) -->
+          <div v-if="form.type === 'lab' || form.type === 'challenge'">
+            <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">
+              Lab Environment URL
+              <span class="font-normal text-gray-400 ml-1">(StackBlitz, Killercoda, Codespace…)</span>
+            </label>
+            <UInput v-model="form.lab_url" placeholder="https://stackblitz.com/edit/…" />
+          </div>
+
+          <!-- Challenge prompt (for challenge type) -->
+          <div v-if="form.type === 'challenge'">
+            <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">Challenge Prompt</label>
+            <UTextarea v-model="form.challenge_prompt" :rows="2"
+              placeholder="Describe what the student must accomplish…" />
+          </div>
+
+          <!-- Instructions (for lab/challenge) -->
+          <div v-if="form.type === 'lab' || form.type === 'challenge'">
+            <div class="mb-1.5 flex items-center justify-between">
+              <label class="text-xs font-semibold text-gray-700 dark:text-gray-300">
+                Step-by-step Instructions
+              </label>
+              <UButton size="xs" variant="ghost" icon="i-heroicons-plus" @click="addInstruction">Add</UButton>
+            </div>
+            <div v-for="(inst, ii) in form.instructions" :key="inst.id" class="mb-2 flex gap-2 items-center">
+              <span class="text-xs text-gray-400 w-5 shrink-0 text-right">{{ ii + 1 }}.</span>
+              <UInput v-model="inst.text" :placeholder="`Step ${ii + 1}…`" class="flex-1" />
+              <UButton icon="i-heroicons-x-mark" size="xs" color="red" variant="ghost"
+                @click="form.instructions.splice(ii, 1)" />
+            </div>
+            <p v-if="!form.instructions.length" class="text-xs text-gray-400 dark:text-gray-500 italic">
+              No instructions yet. Add checkable steps for the student to follow.
+            </p>
           </div>
 
           <!-- Linked course -->
@@ -220,7 +276,7 @@
 
         <div class="mt-6 flex justify-end gap-2">
           <UButton color="gray" variant="outline" @click="showModal = false; stepError = null">Cancel</UButton>
-          <UButton color="indigo" :loading="saving" @click="saveStep">
+          <UButton color="teal" :loading="saving" @click="saveStep">
             {{ editingStep ? 'Save Changes' : 'Add Step' }}
           </UButton>
         </div>
@@ -252,7 +308,16 @@ const saving      = ref(false)
 const stepError   = ref<string | null>(null)
 const editingStep = ref<PathStep | null>(null)
 
-const emptyForm = () => ({ title: '', description: '', course_id: null as number | null, resources: [] as { label: string; url: string }[] })
+const emptyForm = () => ({
+  title: '',
+  description: '',
+  course_id: null as number | null,
+  type: 'reading' as 'reading' | 'lab' | 'challenge' | 'quiz',
+  lab_url: '',
+  instructions: [] as { id: number; text: string }[],
+  challenge_prompt: '',
+  resources: [] as { label: string; url: string }[],
+})
 const form = reactive(emptyForm())
 
 const pathId = computed(() => Number(route.params.id))
@@ -281,6 +346,14 @@ function nodeClass(step: PathStep) {
   return 'border-gray-300 bg-white text-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400'
 }
 
+function stepTypeLabel(type: string) {
+  return { lab: '🧪 Lab', challenge: '🎯 Challenge', quiz: '❓ Quiz', reading: '📖 Reading' }[type] ?? type
+}
+
+function stepTypeBadgeColor(type: string) {
+  return { lab: 'teal', challenge: 'amber', quiz: 'violet', reading: 'gray' }[type] ?? 'gray'
+}
+
 function openAddStep() {
   editingStep.value = null
   stepError.value = null
@@ -292,10 +365,14 @@ function openEditStep(step: PathStep) {
   editingStep.value = step
   stepError.value = null
   Object.assign(form, {
-    title: step.title,
-    description: step.description ?? '',
-    course_id: step.course?.id ?? null,
-    resources: step.resources ? JSON.parse(JSON.stringify(step.resources)) : [],
+    title:            step.title,
+    description:      step.description ?? '',
+    course_id:        step.course?.id ?? null,
+    type:             step.type ?? 'reading',
+    lab_url:          step.lab_url ?? '',
+    instructions:     step.instructions ? JSON.parse(JSON.stringify(step.instructions)) : [],
+    challenge_prompt: step.challenge_prompt ?? '',
+    resources:        step.resources ? JSON.parse(JSON.stringify(step.resources)) : [],
   })
   showModal.value = true
 }
@@ -304,15 +381,24 @@ function addResource() {
   form.resources.push({ label: '', url: '' })
 }
 
+function addInstruction() {
+  const nextId = (form.instructions[form.instructions.length - 1]?.id ?? 0) + 1
+  form.instructions.push({ id: nextId, text: '' })
+}
+
 async function saveStep() {
   if (!form.title.trim()) return
   saving.value = true
   try {
-    const payload = {
-      title: form.title,
-      description: form.description || null,
-      course_id: form.course_id || null,
-      resources: form.resources.filter(r => r.label && r.url),
+    const payload: any = {
+      title:            form.title,
+      description:      form.description || null,
+      course_id:        form.course_id || null,
+      type:             form.type,
+      lab_url:          form.lab_url || null,
+      instructions:     form.instructions.filter(i => i.text.trim()),
+      challenge_prompt: form.challenge_prompt || null,
+      resources:        form.resources.filter(r => r.label && r.url),
     }
     if (editingStep.value) {
       const res = await updateStep(pathId.value, editingStep.value.id, payload)

--- a/frontend/pages/paths/[id].vue
+++ b/frontend/pages/paths/[id].vue
@@ -3,7 +3,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-24">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
     </div>
 
     <template v-else-if="currentPath">
@@ -24,20 +24,20 @@
           <div class="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-              :class="view === 'timeline' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+              :class="view === 'timeline' ? 'bg-emerald-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
               @click="view = 'timeline'"
             >
               <UIcon name="i-heroicons-bars-3-bottom-left" class="h-3.5 w-3.5" /> Timeline
             </button>
             <button
               class="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors"
-              :class="view === 'roadmap' ? 'bg-teal-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
+              :class="view === 'roadmap' ? 'bg-emerald-600 text-white' : 'text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'"
               @click="view = 'roadmap'"
             >
               <UIcon name="i-heroicons-map" class="h-3.5 w-3.5" /> Roadmap
             </button>
           </div>
-          <UButton icon="i-heroicons-plus" size="sm" color="teal" @click="openAddStep">
+          <UButton icon="i-heroicons-plus" size="sm" color="emerald" @click="openAddStep">
             Add Step
           </UButton>
         </div>
@@ -80,7 +80,7 @@
 
               <!-- Card -->
               <div class="mb-4 flex-1 rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-                :class="{ 'ring-2 ring-teal-200 dark:ring-teal-800': editingStep?.id === step.id }">
+                :class="{ 'ring-2 ring-emerald-200 dark:ring-emerald-800': editingStep?.id === step.id }">
                 <div class="flex items-start justify-between gap-3 p-4">
                   <div class="min-w-0 flex-1">
                     <p class="font-semibold text-gray-900 dark:text-white">{{ step.title }}</p>
@@ -93,11 +93,11 @@
                         {{ stepTypeLabel(step.type) }}
                       </UBadge>
                       <UButton v-if="step.type === 'lab' || step.type === 'challenge'"
-                        size="xs" color="teal" variant="soft" icon="i-heroicons-command-line"
+                        size="xs" color="emerald" variant="soft" icon="i-heroicons-command-line"
                         @click.stop="navigateTo(`/labs/${step.id}`)">
                         Open Lab
                       </UButton>
-                      <UBadge v-if="step.course" color="teal" variant="subtle" size="xs" icon="i-heroicons-book-open">
+                      <UBadge v-if="step.course" color="emerald" variant="subtle" size="xs" icon="i-heroicons-book-open">
                         {{ step.course.name }}
                       </UBadge>
                     </div>
@@ -105,7 +105,7 @@
                     <div v-if="step.resources?.length" class="mt-2 flex flex-wrap gap-2">
                       <a v-for="r in step.resources" :key="r.url"
                         :href="r.url" target="_blank"
-                        class="flex items-center gap-1 text-xs text-teal-600 hover:underline dark:text-teal-400">
+                        class="flex items-center gap-1 text-xs text-emerald-600 hover:underline dark:text-emerald-400">
                         <UIcon name="i-heroicons-link" class="h-3 w-3" />
                         {{ r.label }}
                       </a>
@@ -159,9 +159,9 @@
           </div>
 
           <!-- Tip -->
-          <div class="rounded-xl bg-teal-50 p-4 dark:bg-teal-950/30">
-            <p class="text-xs font-semibold text-teal-700 dark:text-teal-400">Tip</p>
-            <p class="mt-1 text-xs text-teal-600 dark:text-teal-500 leading-relaxed">
+          <div class="rounded-xl bg-emerald-50 p-4 dark:bg-emerald-950/30">
+            <p class="text-xs font-semibold text-emerald-700 dark:text-emerald-400">Tip</p>
+            <p class="mt-1 text-xs text-emerald-600 dark:text-emerald-500 leading-relaxed">
               Use the ↑ ↓ arrows to reorder steps. Link a course to each step so clients can access content directly from their roadmap.
             </p>
           </div>
@@ -276,7 +276,7 @@
 
         <div class="mt-6 flex justify-end gap-2">
           <UButton color="gray" variant="outline" @click="showModal = false; stepError = null">Cancel</UButton>
-          <UButton color="teal" :loading="saving" @click="saveStep">
+          <UButton color="emerald" :loading="saving" @click="saveStep">
             {{ editingStep ? 'Save Changes' : 'Add Step' }}
           </UButton>
         </div>
@@ -351,7 +351,7 @@ function stepTypeLabel(type: string) {
 }
 
 function stepTypeBadgeColor(type: string) {
-  return { lab: 'teal', challenge: 'amber', quiz: 'violet', reading: 'gray' }[type] ?? 'gray'
+  return { lab: 'emerald', challenge: 'amber', quiz: 'violet', reading: 'gray' }[type] ?? 'gray'
 }
 
 function openAddStep() {

--- a/frontend/pages/paths/create.vue
+++ b/frontend/pages/paths/create.vue
@@ -47,7 +47,7 @@
           </div>
 
           <div class="mt-6 flex items-center gap-3">
-            <UButton type="submit" color="indigo" size="md" :loading="saving"
+            <UButton type="submit" color="teal" size="md" :loading="saving"
               :disabled="!form.name.trim() || saving">
               Create Path
             </UButton>

--- a/frontend/pages/paths/create.vue
+++ b/frontend/pages/paths/create.vue
@@ -47,7 +47,7 @@
           </div>
 
           <div class="mt-6 flex items-center gap-3">
-            <UButton type="submit" color="teal" size="md" :loading="saving"
+            <UButton type="submit" color="emerald" size="md" :loading="saving"
               :disabled="!form.name.trim() || saving">
               Create Path
             </UButton>

--- a/frontend/pages/plans/[id].vue
+++ b/frontend/pages/plans/[id].vue
@@ -2,7 +2,7 @@
   <NuxtLayout name="admin">
 
     <div v-if="loading" class="flex justify-center py-20">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-indigo-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
     </div>
 
     <template v-else-if="plan">
@@ -32,14 +32,14 @@
         <div class="lg:col-span-2 flex flex-col gap-5">
 
           <!-- Edit name/description -->
-          <div v-if="editMode" class="rounded-xl border border-indigo-200 bg-white p-6 dark:border-indigo-800 dark:bg-gray-800">
+          <div v-if="editMode" class="rounded-xl border border-teal-200 bg-white p-6 dark:border-teal-800 dark:bg-gray-800">
             <h2 class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">Edit Details</h2>
             <div class="flex flex-col gap-4">
               <UInput v-model="editForm.name" label="Name" placeholder="Plan name" size="lg" />
               <UTextarea v-model="editForm.description" label="Description" :rows="3" />
             </div>
             <div class="mt-4 flex gap-2">
-              <UButton color="indigo" :loading="saving" @click="handleSave">Save Changes</UButton>
+              <UButton color="teal" :loading="saving" @click="handleSave">Save Changes</UButton>
               <UButton color="gray" variant="outline" @click="editMode = false">Cancel</UButton>
             </div>
           </div>
@@ -59,8 +59,8 @@
               </div>
               <div v-for="path in plan.paths" :key="path.id"
                 class="flex items-center gap-3 px-5 py-3">
-                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-indigo-50 dark:bg-indigo-950">
-                  <UIcon name="i-heroicons-map" class="h-4 w-4 text-indigo-500" />
+                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-teal-50 dark:bg-teal-950">
+                  <UIcon name="i-heroicons-map" class="h-4 w-4 text-teal-500" />
                 </div>
                 <span class="flex-1 text-sm font-medium text-gray-800 dark:text-gray-200">{{ path.name }}</span>
                 <UButton icon="i-heroicons-arrow-top-right-on-square" size="xs" color="gray" variant="ghost"
@@ -140,19 +140,19 @@
             :key="path.id"
             class="flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors"
             :class="selectedPathIds.includes(path.id)
-              ? 'border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-950/30'
+              ? 'border-teal-200 bg-teal-50 dark:border-teal-800 dark:bg-teal-950/30'
               : 'border-gray-100 hover:bg-gray-50 dark:border-gray-700'"
           >
             <input type="checkbox" class="hidden" :value="path.id" v-model="selectedPathIds" />
-            <UIcon name="i-heroicons-map" class="h-4 w-4 text-indigo-400" />
+            <UIcon name="i-heroicons-map" class="h-4 w-4 text-teal-400" />
             <span class="flex-1 text-sm text-gray-800 dark:text-gray-200">{{ path.name }}</span>
-            <UIcon v-if="selectedPathIds.includes(path.id)" name="i-heroicons-check-circle" class="h-5 w-5 text-indigo-500" />
+            <UIcon v-if="selectedPathIds.includes(path.id)" name="i-heroicons-check-circle" class="h-5 w-5 text-teal-500" />
           </label>
           <p v-if="!availablePaths.length" class="text-sm text-gray-400 py-4 text-center">All paths already added.</p>
         </div>
         <div class="mt-5 flex justify-end gap-2">
           <UButton color="gray" variant="outline" @click="showAddPath = false">Cancel</UButton>
-          <UButton color="indigo" :loading="saving" :disabled="!selectedPathIds.length" @click="handleAddPaths">
+          <UButton color="teal" :loading="saving" :disabled="!selectedPathIds.length" @click="handleAddPaths">
             Add {{ selectedPathIds.length || '' }} Path{{ selectedPathIds.length !== 1 ? 's' : '' }}
           </UButton>
         </div>

--- a/frontend/pages/plans/[id].vue
+++ b/frontend/pages/plans/[id].vue
@@ -2,7 +2,7 @@
   <NuxtLayout name="admin">
 
     <div v-if="loading" class="flex justify-center py-20">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
     </div>
 
     <template v-else-if="plan">
@@ -32,14 +32,14 @@
         <div class="lg:col-span-2 flex flex-col gap-5">
 
           <!-- Edit name/description -->
-          <div v-if="editMode" class="rounded-xl border border-teal-200 bg-white p-6 dark:border-teal-800 dark:bg-gray-800">
+          <div v-if="editMode" class="rounded-xl border border-emerald-200 bg-white p-6 dark:border-emerald-800 dark:bg-gray-800">
             <h2 class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">Edit Details</h2>
             <div class="flex flex-col gap-4">
               <UInput v-model="editForm.name" label="Name" placeholder="Plan name" size="lg" />
               <UTextarea v-model="editForm.description" label="Description" :rows="3" />
             </div>
             <div class="mt-4 flex gap-2">
-              <UButton color="teal" :loading="saving" @click="handleSave">Save Changes</UButton>
+              <UButton color="emerald" :loading="saving" @click="handleSave">Save Changes</UButton>
               <UButton color="gray" variant="outline" @click="editMode = false">Cancel</UButton>
             </div>
           </div>
@@ -59,8 +59,8 @@
               </div>
               <div v-for="path in plan.paths" :key="path.id"
                 class="flex items-center gap-3 px-5 py-3">
-                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-teal-50 dark:bg-teal-950">
-                  <UIcon name="i-heroicons-map" class="h-4 w-4 text-teal-500" />
+                <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-50 dark:bg-emerald-950">
+                  <UIcon name="i-heroicons-map" class="h-4 w-4 text-emerald-500" />
                 </div>
                 <span class="flex-1 text-sm font-medium text-gray-800 dark:text-gray-200">{{ path.name }}</span>
                 <UButton icon="i-heroicons-arrow-top-right-on-square" size="xs" color="gray" variant="ghost"
@@ -140,19 +140,19 @@
             :key="path.id"
             class="flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors"
             :class="selectedPathIds.includes(path.id)
-              ? 'border-teal-200 bg-teal-50 dark:border-teal-800 dark:bg-teal-950/30'
+              ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/30'
               : 'border-gray-100 hover:bg-gray-50 dark:border-gray-700'"
           >
             <input type="checkbox" class="hidden" :value="path.id" v-model="selectedPathIds" />
-            <UIcon name="i-heroicons-map" class="h-4 w-4 text-teal-400" />
+            <UIcon name="i-heroicons-map" class="h-4 w-4 text-emerald-400" />
             <span class="flex-1 text-sm text-gray-800 dark:text-gray-200">{{ path.name }}</span>
-            <UIcon v-if="selectedPathIds.includes(path.id)" name="i-heroicons-check-circle" class="h-5 w-5 text-teal-500" />
+            <UIcon v-if="selectedPathIds.includes(path.id)" name="i-heroicons-check-circle" class="h-5 w-5 text-emerald-500" />
           </label>
           <p v-if="!availablePaths.length" class="text-sm text-gray-400 py-4 text-center">All paths already added.</p>
         </div>
         <div class="mt-5 flex justify-end gap-2">
           <UButton color="gray" variant="outline" @click="showAddPath = false">Cancel</UButton>
-          <UButton color="teal" :loading="saving" :disabled="!selectedPathIds.length" @click="handleAddPaths">
+          <UButton color="emerald" :loading="saving" :disabled="!selectedPathIds.length" @click="handleAddPaths">
             Add {{ selectedPathIds.length || '' }} Path{{ selectedPathIds.length !== 1 ? 's' : '' }}
           </UButton>
         </div>

--- a/frontend/pages/plans/create.vue
+++ b/frontend/pages/plans/create.vue
@@ -42,11 +42,11 @@
           </div>
           <div class="p-6">
             <div v-if="pathsLoading" class="flex justify-center py-6">
-              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-indigo-400" />
+              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-teal-400" />
             </div>
             <div v-else-if="!allPaths.length" class="text-sm text-gray-400 dark:text-gray-500">
               No paths available.
-              <NuxtLink to="/paths/create" class="text-indigo-500 hover:underline">Create one first.</NuxtLink>
+              <NuxtLink to="/paths/create" class="text-teal-500 hover:underline">Create one first.</NuxtLink>
             </div>
             <div v-else class="flex flex-col gap-2">
               <label
@@ -54,18 +54,18 @@
                 :key="path.id"
                 class="flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors"
                 :class="form.path_ids.includes(path.id)
-                  ? 'border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-950/30'
+                  ? 'border-teal-200 bg-teal-50 dark:border-teal-800 dark:bg-teal-950/30'
                   : 'border-gray-100 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/30'"
               >
                 <input type="checkbox" class="hidden" :value="path.id" v-model="form.path_ids" />
                 <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
-                  :class="form.path_ids.includes(path.id) ? 'bg-indigo-100 dark:bg-indigo-900/50' : 'bg-gray-100 dark:bg-gray-700'">
+                  :class="form.path_ids.includes(path.id) ? 'bg-teal-100 dark:bg-teal-900/50' : 'bg-gray-100 dark:bg-gray-700'">
                   <UIcon name="i-heroicons-map" class="h-4 w-4"
-                    :class="form.path_ids.includes(path.id) ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-400'" />
+                    :class="form.path_ids.includes(path.id) ? 'text-teal-600 dark:text-teal-400' : 'text-gray-400'" />
                 </div>
                 <span class="flex-1 text-sm font-medium text-gray-800 dark:text-gray-200">{{ path.name }}</span>
                 <UIcon v-if="form.path_ids.includes(path.id)"
-                  name="i-heroicons-check-circle" class="h-5 w-5 text-indigo-500" />
+                  name="i-heroicons-check-circle" class="h-5 w-5 text-teal-500" />
               </label>
             </div>
           </div>
@@ -81,7 +81,7 @@
             <UInput v-model="clientSearch" placeholder="Search clients…" icon="i-heroicons-magnifying-glass"
               size="sm" class="mb-3" />
             <div v-if="usersLoading" class="flex justify-center py-6">
-              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-indigo-400" />
+              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-teal-400" />
             </div>
             <div v-else-if="!filteredClients.length" class="text-sm text-gray-400 dark:text-gray-500">
               No clients found.
@@ -130,7 +130,7 @@
             {{ error }}
           </div>
 
-          <UButton type="button" block color="indigo" size="md" class="mt-5" :loading="saving"
+          <UButton type="button" block color="teal" size="md" class="mt-5" :loading="saving"
             :disabled="!form.name.trim() || saving" @click="handleSubmit">
             Create Plan
           </UButton>

--- a/frontend/pages/plans/create.vue
+++ b/frontend/pages/plans/create.vue
@@ -42,11 +42,11 @@
           </div>
           <div class="p-6">
             <div v-if="pathsLoading" class="flex justify-center py-6">
-              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-teal-400" />
+              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-emerald-400" />
             </div>
             <div v-else-if="!allPaths.length" class="text-sm text-gray-400 dark:text-gray-500">
               No paths available.
-              <NuxtLink to="/paths/create" class="text-teal-500 hover:underline">Create one first.</NuxtLink>
+              <NuxtLink to="/paths/create" class="text-emerald-500 hover:underline">Create one first.</NuxtLink>
             </div>
             <div v-else class="flex flex-col gap-2">
               <label
@@ -54,18 +54,18 @@
                 :key="path.id"
                 class="flex cursor-pointer items-center gap-3 rounded-lg border p-3 transition-colors"
                 :class="form.path_ids.includes(path.id)
-                  ? 'border-teal-200 bg-teal-50 dark:border-teal-800 dark:bg-teal-950/30'
+                  ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/30'
                   : 'border-gray-100 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700/30'"
               >
                 <input type="checkbox" class="hidden" :value="path.id" v-model="form.path_ids" />
                 <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
-                  :class="form.path_ids.includes(path.id) ? 'bg-teal-100 dark:bg-teal-900/50' : 'bg-gray-100 dark:bg-gray-700'">
+                  :class="form.path_ids.includes(path.id) ? 'bg-emerald-100 dark:bg-emerald-900/50' : 'bg-gray-100 dark:bg-gray-700'">
                   <UIcon name="i-heroicons-map" class="h-4 w-4"
-                    :class="form.path_ids.includes(path.id) ? 'text-teal-600 dark:text-teal-400' : 'text-gray-400'" />
+                    :class="form.path_ids.includes(path.id) ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-400'" />
                 </div>
                 <span class="flex-1 text-sm font-medium text-gray-800 dark:text-gray-200">{{ path.name }}</span>
                 <UIcon v-if="form.path_ids.includes(path.id)"
-                  name="i-heroicons-check-circle" class="h-5 w-5 text-teal-500" />
+                  name="i-heroicons-check-circle" class="h-5 w-5 text-emerald-500" />
               </label>
             </div>
           </div>
@@ -81,7 +81,7 @@
             <UInput v-model="clientSearch" placeholder="Search clients…" icon="i-heroicons-magnifying-glass"
               size="sm" class="mb-3" />
             <div v-if="usersLoading" class="flex justify-center py-6">
-              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-teal-400" />
+              <UIcon name="i-heroicons-arrow-path" class="animate-spin text-emerald-400" />
             </div>
             <div v-else-if="!filteredClients.length" class="text-sm text-gray-400 dark:text-gray-500">
               No clients found.
@@ -130,7 +130,7 @@
             {{ error }}
           </div>
 
-          <UButton type="button" block color="teal" size="md" class="mt-5" :loading="saving"
+          <UButton type="button" block color="emerald" size="md" class="mt-5" :loading="saving"
             :disabled="!form.name.trim() || saving" @click="handleSubmit">
             Create Plan
           </UButton>

--- a/frontend/pages/plans/index.vue
+++ b/frontend/pages/plans/index.vue
@@ -6,24 +6,24 @@
         <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Plans</h1>
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Assign paths and clients to structured coaching plans</p>
       </div>
-      <UButton icon="i-heroicons-plus" size="sm" color="indigo" @click="navigateTo('/plans/create')">
+      <UButton icon="i-heroicons-plus" size="sm" color="teal" @click="navigateTo('/plans/create')">
         New Plan
       </UButton>
     </div>
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-20">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-indigo-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
     </div>
 
     <!-- Empty -->
     <div v-else-if="!plans.length" class="flex flex-col items-center rounded-xl border border-dashed border-gray-200 bg-white py-20 text-center dark:border-gray-700 dark:bg-gray-800">
-      <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-indigo-50 dark:bg-indigo-950">
-        <UIcon name="i-heroicons-clipboard-document-list" class="h-8 w-8 text-indigo-400" />
+      <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
+        <UIcon name="i-heroicons-clipboard-document-list" class="h-8 w-8 text-teal-400" />
       </div>
       <p class="text-sm font-medium text-gray-700 dark:text-gray-300">No plans yet</p>
       <p class="mt-1 max-w-xs text-xs text-gray-400 dark:text-gray-500">Create a plan to bundle paths and assign clients.</p>
-      <UButton size="sm" color="indigo" class="mt-5" icon="i-heroicons-plus" @click="navigateTo('/plans/create')">
+      <UButton size="sm" color="teal" class="mt-5" icon="i-heroicons-plus" @click="navigateTo('/plans/create')">
         Create First Plan
       </UButton>
     </div>
@@ -37,8 +37,8 @@
       >
         <div class="flex-1 p-5">
           <div class="mb-3 flex items-start justify-between gap-2">
-            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-indigo-50 dark:bg-indigo-950">
-              <UIcon name="i-heroicons-clipboard-document-list" class="h-5 w-5 text-indigo-500" />
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-teal-50 dark:bg-teal-950">
+              <UIcon name="i-heroicons-clipboard-document-list" class="h-5 w-5 text-teal-500" />
             </div>
             <UDropdown :items="planActions(plan)" :popper="{ placement: 'bottom-end' }">
               <UButton icon="i-heroicons-ellipsis-horizontal" color="gray" variant="ghost" size="xs" />
@@ -52,7 +52,7 @@
 
           <div class="mt-4 flex flex-wrap gap-3">
             <div class="flex items-center gap-1.5">
-              <UIcon name="i-heroicons-map" class="h-3.5 w-3.5 text-indigo-400" />
+              <UIcon name="i-heroicons-map" class="h-3.5 w-3.5 text-teal-400" />
               <span class="text-xs text-gray-500 dark:text-gray-400">
                 {{ plan.paths?.length ?? 0 }} path{{ (plan.paths?.length ?? 0) !== 1 ? 's' : '' }}
               </span>

--- a/frontend/pages/plans/index.vue
+++ b/frontend/pages/plans/index.vue
@@ -6,24 +6,24 @@
         <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Plans</h1>
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Assign paths and clients to structured coaching plans</p>
       </div>
-      <UButton icon="i-heroicons-plus" size="sm" color="teal" @click="navigateTo('/plans/create')">
+      <UButton icon="i-heroicons-plus" size="sm" color="emerald" @click="navigateTo('/plans/create')">
         New Plan
       </UButton>
     </div>
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-20">
-      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-teal-500" />
+      <UIcon name="i-heroicons-arrow-path" class="animate-spin text-3xl text-emerald-500" />
     </div>
 
     <!-- Empty -->
     <div v-else-if="!plans.length" class="flex flex-col items-center rounded-xl border border-dashed border-gray-200 bg-white py-20 text-center dark:border-gray-700 dark:bg-gray-800">
-      <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-teal-50 dark:bg-teal-950">
-        <UIcon name="i-heroicons-clipboard-document-list" class="h-8 w-8 text-teal-400" />
+      <div class="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50 dark:bg-emerald-950">
+        <UIcon name="i-heroicons-clipboard-document-list" class="h-8 w-8 text-emerald-400" />
       </div>
       <p class="text-sm font-medium text-gray-700 dark:text-gray-300">No plans yet</p>
       <p class="mt-1 max-w-xs text-xs text-gray-400 dark:text-gray-500">Create a plan to bundle paths and assign clients.</p>
-      <UButton size="sm" color="teal" class="mt-5" icon="i-heroicons-plus" @click="navigateTo('/plans/create')">
+      <UButton size="sm" color="emerald" class="mt-5" icon="i-heroicons-plus" @click="navigateTo('/plans/create')">
         Create First Plan
       </UButton>
     </div>
@@ -37,8 +37,8 @@
       >
         <div class="flex-1 p-5">
           <div class="mb-3 flex items-start justify-between gap-2">
-            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-teal-50 dark:bg-teal-950">
-              <UIcon name="i-heroicons-clipboard-document-list" class="h-5 w-5 text-teal-500" />
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-emerald-50 dark:bg-emerald-950">
+              <UIcon name="i-heroicons-clipboard-document-list" class="h-5 w-5 text-emerald-500" />
             </div>
             <UDropdown :items="planActions(plan)" :popper="{ placement: 'bottom-end' }">
               <UButton icon="i-heroicons-ellipsis-horizontal" color="gray" variant="ghost" size="xs" />
@@ -52,7 +52,7 @@
 
           <div class="mt-4 flex flex-wrap gap-3">
             <div class="flex items-center gap-1.5">
-              <UIcon name="i-heroicons-map" class="h-3.5 w-3.5 text-teal-400" />
+              <UIcon name="i-heroicons-map" class="h-3.5 w-3.5 text-emerald-400" />
               <span class="text-xs text-gray-500 dark:text-gray-400">
                 {{ plan.paths?.length ?? 0 }} path{{ (plan.paths?.length ?? 0) !== 1 ? 's' : '' }}
               </span>

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -30,12 +30,12 @@
               :src="avatarPreview || user?.profile?.profile_image_url || '/images/team-13.jpg'"
               :alt="user?.fullname"
               size="3xl"
-              class="ring-4 ring-indigo-100 dark:ring-indigo-900"
+              class="ring-4 ring-teal-100 dark:ring-teal-900"
             />
             <button
               class="absolute bottom-0 right-0 flex h-7 w-7 items-center justify-center
-                     rounded-full border-2 border-white bg-indigo-600 text-white shadow
-                     hover:bg-indigo-700 dark:border-gray-800"
+                     rounded-full border-2 border-white bg-teal-600 text-white shadow
+                     hover:bg-teal-700 dark:border-gray-800"
               title="Change photo"
               :disabled="uploadingAvatar"
               @click="$refs.avatarInput.click()"
@@ -53,7 +53,7 @@
           </div>
           <h3 class="text-base font-bold text-gray-900 dark:text-white">{{ user?.fullname }}</h3>
           <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 capitalize">{{ user?.role }}</p>
-          <UBadge color="indigo" variant="subtle" size="xs" class="mt-2">
+          <UBadge color="teal" variant="subtle" size="xs" class="mt-2">
             {{ user?.email }}
           </UBadge>
         </div>
@@ -79,14 +79,14 @@
                     type="url"
                     :placeholder="`https://...`"
                     class="mt-0.5 w-full rounded-md border border-gray-200 bg-gray-50 px-2 py-1
-                           text-xs text-gray-800 outline-none focus:border-indigo-400
+                           text-xs text-gray-800 outline-none focus:border-teal-400
                            dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
                   />
                 </template>
                 <template v-else>
                   <a v-if="user?.profile?.[link.key]"
                     :href="user.profile[link.key]" target="_blank"
-                    class="truncate text-xs text-indigo-600 hover:underline dark:text-indigo-400">
+                    class="truncate text-xs text-teal-600 hover:underline dark:text-teal-400">
                     {{ user.profile[link.key] }}
                   </a>
                   <p v-else class="text-xs italic text-gray-400 dark:text-gray-500">Not set</p>
@@ -117,7 +117,7 @@
                 <input v-if="editing" v-model="form.fullname"
                   type="text"
                   class="mt-1 w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5
-                         text-sm text-gray-800 outline-none focus:border-indigo-400
+                         text-sm text-gray-800 outline-none focus:border-teal-400
                          dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
                 <p v-else class="mt-0.5 text-sm font-medium text-gray-900 dark:text-white">
                   {{ user?.fullname || '—' }}
@@ -172,19 +172,19 @@
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">Current Password</label>
               <input v-model="passwordForm.current" type="password"
                 class="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm
-                       outline-none focus:border-indigo-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                       outline-none focus:border-teal-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
             </div>
             <div>
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">New Password</label>
               <input v-model="passwordForm.new" type="password"
                 class="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm
-                       outline-none focus:border-indigo-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                       outline-none focus:border-teal-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
             </div>
             <div>
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">Confirm New Password</label>
               <input v-model="passwordForm.confirm" type="password"
                 class="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm
-                       outline-none focus:border-indigo-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                       outline-none focus:border-teal-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
             </div>
             <div class="flex justify-end gap-2 pt-1">
               <UButton size="sm" color="gray" variant="outline" @click="showPasswordForm = false">Cancel</UButton>
@@ -195,9 +195,9 @@
 
         <!-- Save bar — visible only in edit mode -->
         <div v-if="editing"
-          class="flex items-center justify-between rounded-xl border border-indigo-200 bg-indigo-50
-                 px-5 py-4 dark:border-indigo-800 dark:bg-indigo-950/40">
-          <p class="text-sm text-indigo-700 dark:text-indigo-300">You have unsaved changes.</p>
+          class="flex items-center justify-between rounded-xl border border-teal-200 bg-teal-50
+                 px-5 py-4 dark:border-teal-800 dark:bg-teal-950/40">
+          <p class="text-sm text-teal-700 dark:text-teal-300">You have unsaved changes.</p>
           <div class="flex gap-2">
             <UButton size="sm" color="gray" variant="outline" @click="cancelEdit">Discard</UButton>
             <UButton size="sm" icon="i-heroicons-check" :loading="saving" @click="saveProfile">

--- a/frontend/pages/profile.vue
+++ b/frontend/pages/profile.vue
@@ -30,12 +30,12 @@
               :src="avatarPreview || user?.profile?.profile_image_url || '/images/team-13.jpg'"
               :alt="user?.fullname"
               size="3xl"
-              class="ring-4 ring-teal-100 dark:ring-teal-900"
+              class="ring-4 ring-emerald-100 dark:ring-emerald-900"
             />
             <button
               class="absolute bottom-0 right-0 flex h-7 w-7 items-center justify-center
-                     rounded-full border-2 border-white bg-teal-600 text-white shadow
-                     hover:bg-teal-700 dark:border-gray-800"
+                     rounded-full border-2 border-white bg-emerald-600 text-white shadow
+                     hover:bg-emerald-700 dark:border-gray-800"
               title="Change photo"
               :disabled="uploadingAvatar"
               @click="$refs.avatarInput.click()"
@@ -53,7 +53,7 @@
           </div>
           <h3 class="text-base font-bold text-gray-900 dark:text-white">{{ user?.fullname }}</h3>
           <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400 capitalize">{{ user?.role }}</p>
-          <UBadge color="teal" variant="subtle" size="xs" class="mt-2">
+          <UBadge color="emerald" variant="subtle" size="xs" class="mt-2">
             {{ user?.email }}
           </UBadge>
         </div>
@@ -79,14 +79,14 @@
                     type="url"
                     :placeholder="`https://...`"
                     class="mt-0.5 w-full rounded-md border border-gray-200 bg-gray-50 px-2 py-1
-                           text-xs text-gray-800 outline-none focus:border-teal-400
+                           text-xs text-gray-800 outline-none focus:border-emerald-400
                            dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
                   />
                 </template>
                 <template v-else>
                   <a v-if="user?.profile?.[link.key]"
                     :href="user.profile[link.key]" target="_blank"
-                    class="truncate text-xs text-teal-600 hover:underline dark:text-teal-400">
+                    class="truncate text-xs text-emerald-600 hover:underline dark:text-emerald-400">
                     {{ user.profile[link.key] }}
                   </a>
                   <p v-else class="text-xs italic text-gray-400 dark:text-gray-500">Not set</p>
@@ -117,7 +117,7 @@
                 <input v-if="editing" v-model="form.fullname"
                   type="text"
                   class="mt-1 w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-1.5
-                         text-sm text-gray-800 outline-none focus:border-teal-400
+                         text-sm text-gray-800 outline-none focus:border-emerald-400
                          dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
                 <p v-else class="mt-0.5 text-sm font-medium text-gray-900 dark:text-white">
                   {{ user?.fullname || '—' }}
@@ -172,19 +172,19 @@
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">Current Password</label>
               <input v-model="passwordForm.current" type="password"
                 class="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm
-                       outline-none focus:border-teal-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                       outline-none focus:border-emerald-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
             </div>
             <div>
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">New Password</label>
               <input v-model="passwordForm.new" type="password"
                 class="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm
-                       outline-none focus:border-teal-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                       outline-none focus:border-emerald-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
             </div>
             <div>
               <label class="mb-1 block text-xs font-medium text-gray-600 dark:text-gray-400">Confirm New Password</label>
               <input v-model="passwordForm.confirm" type="password"
                 class="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm
-                       outline-none focus:border-teal-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
+                       outline-none focus:border-emerald-400 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200" />
             </div>
             <div class="flex justify-end gap-2 pt-1">
               <UButton size="sm" color="gray" variant="outline" @click="showPasswordForm = false">Cancel</UButton>
@@ -195,9 +195,9 @@
 
         <!-- Save bar — visible only in edit mode -->
         <div v-if="editing"
-          class="flex items-center justify-between rounded-xl border border-teal-200 bg-teal-50
-                 px-5 py-4 dark:border-teal-800 dark:bg-teal-950/40">
-          <p class="text-sm text-teal-700 dark:text-teal-300">You have unsaved changes.</p>
+          class="flex items-center justify-between rounded-xl border border-emerald-200 bg-emerald-50
+                 px-5 py-4 dark:border-emerald-800 dark:bg-emerald-950/40">
+          <p class="text-sm text-emerald-700 dark:text-emerald-300">You have unsaved changes.</p>
           <div class="flex gap-2">
             <UButton size="sm" color="gray" variant="outline" @click="cancelEdit">Discard</UButton>
             <UButton size="sm" icon="i-heroicons-check" :loading="saving" @click="saveProfile">

--- a/frontend/pages/users/[id].vue
+++ b/frontend/pages/users/[id].vue
@@ -147,7 +147,7 @@
             <div class="md:col-span-2" v-if="selectedUser.profile?.stack?.length">
               <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Stack</label>
               <div class="flex flex-wrap gap-2 mt-2">
-                <UBadge v-for="s in selectedUser.profile.stack" :key="s" color="teal" variant="subtle">
+                <UBadge v-for="s in selectedUser.profile.stack" :key="s" color="emerald" variant="subtle">
                   {{ s }}
                 </UBadge>
               </div>

--- a/frontend/pages/users/[id].vue
+++ b/frontend/pages/users/[id].vue
@@ -147,7 +147,7 @@
             <div class="md:col-span-2" v-if="selectedUser.profile?.stack?.length">
               <label class="text-xs font-bold text-gray-400 uppercase tracking-widest">Stack</label>
               <div class="flex flex-wrap gap-2 mt-2">
-                <UBadge v-for="s in selectedUser.profile.stack" :key="s" color="indigo" variant="subtle">
+                <UBadge v-for="s in selectedUser.profile.stack" :key="s" color="teal" variant="subtle">
                   {{ s }}
                 </UBadge>
               </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,6 +52,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::get('/my-paths', [PathController::class, 'myPaths']);
     Route::get('/paths/{path}', [PathController::class, 'show']);
     Route::get('/paths/{path}/steps', [PathStepController::class, 'index']);
+    Route::get('/path-steps/{step}', [PathStepController::class, 'show']);
 
     // Step progress (all authenticated users update their own progress)
     Route::put('/path-steps/{step}/progress', [PathStepController::class, 'updateProgress']);
@@ -79,6 +80,14 @@ Route::middleware(['auth:sanctum'])->group(function () {
     // GDPR — data portability (own data) and erasure (admin only)
     Route::get('/users/{user}/export', [UserController::class, 'exportData']);
     Route::delete('/users/{user}/erase', [UserController::class, 'eraseData']);
+
+    // Consultant — my clients
+    Route::middleware(['role:admin|consultant'])->group(function () {
+        Route::get('/my-clients', [UserController::class, 'myClients']);
+        Route::get('/my-clients/{client}', [UserController::class, 'clientDetail']);
+        Route::post('/my-clients/{client}/paths', [UserController::class, 'assignPath']);
+        Route::delete('/my-clients/{client}/paths/{path}', [UserController::class, 'removePath']);
+    });
 
     // Admin + Consultant
     Route::middleware(['role:admin|consultant'])->group(function () {

--- a/tests/Feature/MyClientsTest.php
+++ b/tests/Feature/MyClientsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Path;
+use App\Models\Plan;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MyClientsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $consultant;
+    private User $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+
+        $this->consultant = User::factory()->create();
+        $this->consultant->assignRole('consultant');
+
+        $this->client = User::factory()->create();
+        $this->client->update(['consultant_id' => $this->consultant->id]);
+    }
+
+    private function asConsultant(): static
+    {
+        return $this->actingAs($this->consultant, 'sanctum');
+    }
+
+    // ── Auth & Role guards ───────────────────────────────────────────────────
+
+    public function test_unauthenticated_cannot_access_my_clients(): void
+    {
+        $this->getJson('/api/my-clients')->assertUnauthorized();
+    }
+
+    public function test_client_role_cannot_access_my_clients(): void
+    {
+        $this->actingAs($this->client, 'sanctum')
+            ->getJson('/api/my-clients')
+            ->assertForbidden();
+    }
+
+    public function test_admin_can_access_my_clients(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $this->actingAs($admin, 'sanctum')
+            ->getJson('/api/my-clients')
+            ->assertOk();
+    }
+
+    // ── List clients ─────────────────────────────────────────────────────────
+
+    public function test_consultant_sees_only_their_own_clients(): void
+    {
+        $otherConsultant = User::factory()->create();
+        $otherConsultant->assignRole('consultant');
+
+        $otherClient = User::factory()->create();
+        $otherClient->update(['consultant_id' => $otherConsultant->id]);
+
+        $response = $this->asConsultant()->getJson('/api/my-clients')->assertOk();
+
+        $ids = collect($response->json('data'))->pluck('id');
+        $this->assertTrue($ids->contains($this->client->id));
+        $this->assertFalse($ids->contains($otherClient->id));
+    }
+
+    public function test_client_list_includes_progress_fields(): void
+    {
+        $response = $this->asConsultant()->getJson('/api/my-clients')->assertOk();
+
+        $item = collect($response->json('data'))->firstWhere('id', $this->client->id);
+        $this->assertNotNull($item);
+        $this->assertArrayHasKey('path_count',   $item);
+        $this->assertArrayHasKey('progress_pct', $item);
+        $this->assertArrayHasKey('done_steps',   $item);
+        $this->assertArrayHasKey('total_steps',  $item);
+    }
+
+    // ── Client detail ────────────────────────────────────────────────────────
+
+    public function test_consultant_can_fetch_client_detail(): void
+    {
+        $this->asConsultant()
+            ->getJson("/api/my-clients/{$this->client->id}")
+            ->assertOk()
+            ->assertJsonStructure(['user' => ['id', 'fullname', 'email'], 'paths']);
+    }
+
+    public function test_consultant_cannot_fetch_another_consultants_client(): void
+    {
+        $stranger = User::factory()->create();
+
+        $this->asConsultant()
+            ->getJson("/api/my-clients/{$stranger->id}")
+            ->assertForbidden();
+    }
+
+    // ── Assign path ──────────────────────────────────────────────────────────
+
+    public function test_consultant_can_assign_path_to_client(): void
+    {
+        $path = Path::create(['name' => 'Laravel Track', 'consultant_id' => $this->consultant->id]);
+
+        $this->asConsultant()
+            ->postJson("/api/my-clients/{$this->client->id}/paths", ['path_id' => $path->id])
+            ->assertOk();
+
+        // A plan must exist linking consultant → client → path
+        $plan = Plan::where('consultant_id', $this->consultant->id)
+            ->whereHas('clients', fn ($q) => $q->where('users.id', $this->client->id))
+            ->whereHas('paths',   fn ($q) => $q->where('paths.id', $path->id))
+            ->first();
+
+        $this->assertNotNull($plan);
+    }
+
+    public function test_assigning_path_twice_does_not_duplicate(): void
+    {
+        $path = Path::create(['name' => 'Laravel Track', 'consultant_id' => $this->consultant->id]);
+
+        $this->asConsultant()->postJson("/api/my-clients/{$this->client->id}/paths", ['path_id' => $path->id]);
+        $this->asConsultant()->postJson("/api/my-clients/{$this->client->id}/paths", ['path_id' => $path->id]);
+
+        $count = Plan::where('consultant_id', $this->consultant->id)
+            ->whereHas('clients', fn ($q) => $q->where('users.id', $this->client->id))
+            ->first()
+            ?->paths()->where('paths.id', $path->id)->count();
+
+        $this->assertEquals(1, $count);
+    }
+
+    public function test_assign_requires_valid_path_id(): void
+    {
+        $this->asConsultant()
+            ->postJson("/api/my-clients/{$this->client->id}/paths", ['path_id' => 99999])
+            ->assertUnprocessable();
+    }
+
+    // ── Remove path ──────────────────────────────────────────────────────────
+
+    public function test_consultant_can_remove_path_from_client(): void
+    {
+        $path = Path::create(['name' => 'Laravel Track', 'consultant_id' => $this->consultant->id]);
+
+        $this->asConsultant()->postJson("/api/my-clients/{$this->client->id}/paths", ['path_id' => $path->id]);
+
+        $this->asConsultant()
+            ->deleteJson("/api/my-clients/{$this->client->id}/paths/{$path->id}")
+            ->assertOk();
+
+        $count = Plan::where('consultant_id', $this->consultant->id)
+            ->whereHas('clients', fn ($q) => $q->where('users.id', $this->client->id))
+            ->first()
+            ?->paths()->where('paths.id', $path->id)->count();
+
+        $this->assertEquals(0, $count ?? 0);
+    }
+}

--- a/tests/Feature/StepProgressTest.php
+++ b/tests/Feature/StepProgressTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Path;
+use App\Models\PathStep;
+use App\Models\User;
+use App\Models\UserStepProgress;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StepProgressTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $client;
+    private Path $path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+
+        $this->client = User::factory()->create();
+        $this->path   = Path::create(['name' => 'Test Path', 'consultant_id' => $this->client->id]);
+    }
+
+    private function makeStep(int $order): PathStep
+    {
+        return PathStep::create([
+            'path_id' => $this->path->id,
+            'title'   => "Step {$order}",
+            'order'   => $order,
+        ]);
+    }
+
+    private function setProgress(PathStep $step, string $status): void
+    {
+        UserStepProgress::updateOrCreate(
+            ['user_id' => $this->client->id, 'path_step_id' => $step->id],
+            ['status'  => $status]
+        );
+    }
+
+    private function putProgress(PathStep $step, string $status)
+    {
+        return $this->actingAs($this->client, 'sanctum')
+            ->putJson("/api/path-steps/{$step->id}/progress", ['status' => $status]);
+    }
+
+    // ── Basic ────────────────────────────────────────────────────────────────
+
+    public function test_client_can_update_step_progress(): void
+    {
+        $step = $this->makeStep(1);
+
+        $this->putProgress($step, 'in_progress')->assertOk()->assertJson(['status' => 'in_progress']);
+
+        $this->assertDatabaseHas('user_step_progress', [
+            'user_id'      => $this->client->id,
+            'path_step_id' => $step->id,
+            'status'       => 'in_progress',
+        ]);
+    }
+
+    public function test_unauthenticated_request_is_rejected(): void
+    {
+        $step = $this->makeStep(1);
+
+        $this->putJson("/api/path-steps/{$step->id}/progress", ['status' => 'done'])
+            ->assertUnauthorized();
+    }
+
+    public function test_invalid_status_is_rejected(): void
+    {
+        $step = $this->makeStep(1);
+
+        $this->putProgress($step, 'watching_netflix')->assertUnprocessable();
+    }
+
+    // ── One in_progress per path ─────────────────────────────────────────────
+
+    public function test_setting_in_progress_demotes_other_in_progress_sibling(): void
+    {
+        $step1 = $this->makeStep(1);
+        $step2 = $this->makeStep(2);
+
+        // step1 is already in progress (done first, so order allows step2 to start)
+        $this->setProgress($step1, 'done');
+
+        // step2 in progress
+        $this->setProgress($step2, 'in_progress');
+
+        // now mark step1 somehow back to in_progress (order 1 < order 2, so no block)
+        $this->putProgress($step1, 'in_progress')->assertOk();
+
+        // step2 should have been reset to not_started
+        $this->assertDatabaseHas('user_step_progress', [
+            'user_id'      => $this->client->id,
+            'path_step_id' => $step2->id,
+            'status'       => 'not_started',
+        ]);
+    }
+
+    public function test_setting_in_progress_does_not_affect_other_paths(): void
+    {
+        $otherPath = Path::create(['name' => 'Other Path', 'consultant_id' => $this->client->id]);
+        $stepA     = $this->makeStep(1);
+        $stepB     = PathStep::create(['path_id' => $otherPath->id, 'title' => 'Other step', 'order' => 1]);
+
+        $this->setProgress($stepB, 'in_progress');
+
+        $this->putProgress($stepA, 'in_progress')->assertOk();
+
+        // stepB on a different path must remain in_progress
+        $this->assertDatabaseHas('user_step_progress', [
+            'user_id'      => $this->client->id,
+            'path_step_id' => $stepB->id,
+            'status'       => 'in_progress',
+        ]);
+    }
+
+    // ── Step ordering enforcement ────────────────────────────────────────────
+
+    public function test_cannot_start_step_while_preceding_step_is_in_progress(): void
+    {
+        $step1 = $this->makeStep(1);
+        $step2 = $this->makeStep(2);
+
+        $this->setProgress($step1, 'in_progress');
+
+        $this->putProgress($step2, 'in_progress')->assertUnprocessable();
+
+        // step2 must remain unchanged
+        $this->assertDatabaseMissing('user_step_progress', [
+            'user_id'      => $this->client->id,
+            'path_step_id' => $step2->id,
+            'status'       => 'in_progress',
+        ]);
+    }
+
+    public function test_can_start_step_when_all_preceding_steps_are_done(): void
+    {
+        $step1 = $this->makeStep(1);
+        $step2 = $this->makeStep(2);
+
+        $this->setProgress($step1, 'done');
+
+        $this->putProgress($step2, 'in_progress')->assertOk();
+    }
+
+    public function test_can_start_first_step_with_no_prerequisites(): void
+    {
+        $step1 = $this->makeStep(1);
+
+        $this->putProgress($step1, 'in_progress')->assertOk();
+    }
+
+    public function test_marking_done_is_never_blocked_by_preceding_in_progress(): void
+    {
+        $step1 = $this->makeStep(1);
+        $step2 = $this->makeStep(2);
+
+        $this->setProgress($step1, 'in_progress');
+
+        // Marking step2 done (skipping) is allowed — only in_progress is guarded
+        $this->putProgress($step2, 'done')->assertOk();
+    }
+
+    public function test_can_revert_step_to_not_started_regardless_of_siblings(): void
+    {
+        $step1 = $this->makeStep(1);
+        $step2 = $this->makeStep(2);
+
+        $this->setProgress($step1, 'in_progress');
+        $this->setProgress($step2, 'in_progress');
+
+        $this->putProgress($step2, 'not_started')->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary

- **My Clients flow** — consultant can view assigned clients, see their path/step-level progress, assign and remove paths. Backend enforces ownership (consultant can only manage their own clients).
- **Step progress rules** — one `in_progress` per path at a time (backend resets siblings); cannot start step N while a preceding step is still `in_progress` (returns 422 + frontend blocking modal).
- **Roadmap node click** — opens step detail modal with description, *What you'll learn* checklist, challenge prompt, linked course card, resources, and inline status controls.
- **Udemy-style timeline** — replaces the old connector-line view with a clean accordion: type icon, step number, expand/collapse, structured sections per step.
- **Path header** — shows a *This path includes* breakdown (reading / labs / challenges / resources count).
- **Color palette** — full `teal` → `emerald` sweep across all 14 pages/layouts to align with New Relic green.
- **Courses fix** — consultants were wrongly redirected to `/my-courses`; guard now checks `role === client` only.
- **Factory** — `PathStepFactory` updated with 8 realistic IT career steps (rich descriptions, instructions, resources).

## Test plan

- [x] `StepProgressTest` — 11 cases covering basic update, auth guards, one-in_progress rule, step ordering block, cross-path isolation
- [x] `MyClientsTest` — 10 cases covering role guards, client list isolation, progress fields, assign/remove path idempotency
- [x] Manual end-to-end: consultant assigns path → client sees roadmap → marks progress → blocking modal fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)