### PR TITLE
feat: payments, onboarding redesign, challenges & CV fixes

### DIFF
--- a/app/Enums/ChallengeDifficulty.php
+++ b/app/Enums/ChallengeDifficulty.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum ChallengeDifficulty: string
+{
+    case Beginner = 'beginner';
+    case Intermediate = 'intermediate';
+    case Advanced = 'advanced';
+    case Expert = 'expert';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/Api/CvController.php
+++ b/app/Http/Controllers/Api/CvController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
@@ -13,7 +14,7 @@ class CvController extends Controller
     {
         $request->validate([
             'cv' => 'required|file|mimes:pdf|max:5120',
-            'job_description' => 'required_without:job_url|nullable|string|min:50|max:5000',
+            'job_description' => 'required_without:job_url|nullable|string|min:50|max:15000',
             'job_url' => 'required_without:job_description|nullable|url|max:2048',
         ]);
 
@@ -104,9 +105,13 @@ PROMPT;
 
     private function fetchJobFromUrl(string $url): ?string
     {
-        $response = Http::timeout(15)
-            ->withHeaders(['Accept' => 'text/plain'])
-            ->get('https://r.jina.ai/'.$url);
+        try {
+            $response = Http::timeout(15)
+                ->withHeaders(['Accept' => 'text/plain'])
+                ->get('https://r.jina.ai/'.$url);
+        } catch (ConnectionException) {
+            return null;
+        }
 
         if ($response->failed()) {
             return null;
@@ -114,6 +119,10 @@ PROMPT;
 
         $text = trim($response->body());
 
-        return strlen($text) >= 50 ? $text : null;
+        if (strlen($text) < 50) {
+            return null;
+        }
+
+        return mb_substr($text, 0, 15000);
     }
 }

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -291,7 +291,7 @@ class UserController extends Controller
             'product_interest' => 'required|in:self-serve,bootcamp,mentorship',
             'availability_hours' => 'required|integer|min:1|max:80',
             'timeline' => 'required|in:1-3m,3-6m,6-12m,flexible',
-            'goal' => 'nullable|string|max:500',
+            'goal' => 'required|string|max:255',
         ]);
 
         $user->profile()->updateOrCreate(
@@ -299,6 +299,7 @@ class UserController extends Controller
             $data
         );
 
+        $user->update(['needs_onboarding' => false]);
         $user->load('profile', 'roles');
 
         User::role('admin')->each(fn (User $admin) => $admin->notify(new NewClientOnboarded($user)));

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ChallengeDifficulty;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Challenge extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'title',
+        'slug',
+        'description',
+        'difficulty',
+        'boilerplate_code',
+        'tests_code',
+        'is_premium',
+        'price_eur',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'difficulty' => ChallengeDifficulty::class,
+            'is_premium' => 'boolean',
+        ];
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'google_id',
         'email_verified_at',
         'consultant_id',
+        'needs_onboarding',
     ];
 
     /**
@@ -50,6 +51,7 @@ class User extends Authenticatable implements MustVerifyEmail
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
+        'needs_onboarding' => 'boolean',
     ];
 
     /**

--- a/app/Services/StripeService.php
+++ b/app/Services/StripeService.php
@@ -106,7 +106,7 @@ class StripeService
 
     private function markSessionPaid(Session $session): void
     {
-        $payment = Payment::where('stripe_session_id', $session->id)->first();
+        $payment = Payment::with('user')->where('stripe_session_id', $session->id)->first();
 
         if (! $payment) {
             Log::warning("Stripe checkout.session.completed for unknown session: {$session->id}");
@@ -118,11 +118,16 @@ class StripeService
             return;
         }
 
+        // subscriptions expose $session->subscription, one-time payments expose $session->payment_intent
+        $stripeReference = $session->subscription ?? $session->payment_intent;
+
         $payment->update([
-            'stripe_payment_intent_id' => $session->payment_intent,
+            'stripe_payment_intent_id' => $stripeReference,
             'status' => PaymentStatus::PAID,
             'paid_at' => now(),
         ]);
+
+        $payment->user->update(['needs_onboarding' => true]);
     }
 
     private function markSessionFailed(Session $session): void

--- a/database/migrations/2026_05_03_230739_add_needs_onboarding_to_users_table.php
+++ b/database/migrations/2026_05_03_230739_add_needs_onboarding_to_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('needs_onboarding')->default(false)->after('consultant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('needs_onboarding');
+        });
+    }
+};

--- a/database/migrations/2026_05_04_000000_create_challenges_table.php
+++ b/database/migrations/2026_05_04_000000_create_challenges_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Enums\ChallengeDifficulty;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('challenges', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->longText('description');
+            $table->enum('difficulty', ChallengeDifficulty::values())->default(ChallengeDifficulty::Beginner->value);
+            $table->longText('boilerplate_code');
+            $table->longText('tests_code');
+            $table->boolean('is_premium')->default(false);
+            $table->unsignedInteger('price_eur')->nullable()->comment('Price in euro cents (minor units)');
+            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('challenges');
+    }
+};

--- a/database/seeders/ChallengeSeeder.php
+++ b/database/seeders/ChallengeSeeder.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\ChallengeDifficulty;
+use App\Models\Challenge;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class ChallengeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $admin = User::find(1);
+
+        if (! $admin) {
+            return;
+        }
+
+        $challenges = [
+            [
+                'title' => 'Null-Safe Property Chain',
+                'slug' => 'null-safe-property-chain',
+                'difficulty' => ChallengeDifficulty::Beginner,
+                'description' => <<<'MD'
+## Null-Safe Property Chain
+
+PHP 8.0 introduced the **null-safe operator** `?->` to short-circuit a chain when any member is `null` instead of throwing an error.
+
+**Goal:** implement `getCity()` so it returns the city name from a nested object graph — or `null` if any link in the chain is absent. Use a single expression with `?->`.
+
+```php
+$user?->address?->city?->name
+```
+MD,
+                'boilerplate_code' => <<<'PHP'
+<?php
+
+class City
+{
+    public function __construct(public string $name) {}
+}
+
+class Address
+{
+    public function __construct(public ?City $city = null) {}
+}
+
+class User
+{
+    public function __construct(public ?Address $address = null) {}
+}
+
+function getCity(?User $user): ?string
+{
+    // TODO: return the city name using the null-safe operator,
+    // or null if any part of the chain is absent.
+}
+PHP,
+                'tests_code' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class NullSafeTest extends TestCase
+{
+    public function test_returns_city_name_when_full_chain_exists(): void
+    {
+        $user = new User(new Address(new City('Dublin')));
+        $this->assertSame('Dublin', getCity($user));
+    }
+
+    public function test_returns_null_when_user_is_null(): void
+    {
+        $this->assertNull(getCity(null));
+    }
+
+    public function test_returns_null_when_address_is_null(): void
+    {
+        $this->assertNull(getCity(new User(null)));
+    }
+
+    public function test_returns_null_when_city_is_null(): void
+    {
+        $this->assertNull(getCity(new User(new Address(null))));
+    }
+}
+PHP,
+                'is_premium' => false,
+                'price_eur' => null,
+            ],
+            [
+                'title' => 'Status Enum — Label & Color',
+                'slug' => 'status-enum-label-color',
+                'difficulty' => ChallengeDifficulty::Intermediate,
+                'description' => <<<'MD'
+## Status Enum — Label & Color
+
+PHP 8.1 **backed enums** can carry methods that centralise display logic, keeping `match` expressions out of view templates.
+
+**Goal:** complete the `OrderStatus` enum so that each case returns a human-readable `label()` and a Tailwind CSS `color()` string.
+
+| Case | Label | Color |
+|------|-------|-------|
+| `Pending` | `"Pending payment"` | `"yellow"` |
+| `Paid` | `"Paid"` | `"green"` |
+| `Cancelled` | `"Cancelled"` | `"red"` |
+MD,
+                'boilerplate_code' => <<<'PHP'
+<?php
+
+enum OrderStatus: string
+{
+    case Pending   = 'pending';
+    case Paid      = 'paid';
+    case Cancelled = 'cancelled';
+
+    public function label(): string
+    {
+        // TODO: return human-readable label for each case
+    }
+
+    public function color(): string
+    {
+        // TODO: return Tailwind color name: "yellow", "green", or "red"
+    }
+}
+PHP,
+                'tests_code' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class OrderStatusTest extends TestCase
+{
+    public function test_pending_label_and_color(): void
+    {
+        $this->assertSame('Pending payment', OrderStatus::Pending->label());
+        $this->assertSame('yellow', OrderStatus::Pending->color());
+    }
+
+    public function test_paid_label_and_color(): void
+    {
+        $this->assertSame('Paid', OrderStatus::Paid->label());
+        $this->assertSame('green', OrderStatus::Paid->color());
+    }
+
+    public function test_cancelled_label_and_color(): void
+    {
+        $this->assertSame('Cancelled', OrderStatus::Cancelled->label());
+        $this->assertSame('red', OrderStatus::Cancelled->color());
+    }
+
+    public function test_from_string_returns_correct_case(): void
+    {
+        $this->assertSame(OrderStatus::Paid, OrderStatus::from('paid'));
+    }
+}
+PHP,
+                'is_premium' => false,
+                'price_eur' => null,
+            ],
+            [
+                'title' => 'Enum-Driven State Machine',
+                'slug' => 'enum-driven-state-machine',
+                'difficulty' => ChallengeDifficulty::Advanced,
+                'description' => <<<'MD'
+## Enum-Driven State Machine
+
+Combine PHP 8.1 **enums** with **readonly properties** to build a lightweight state machine. Valid transitions are encoded directly on the enum, making illegal transitions impossible to overlook.
+
+**Goal:** implement `transitions()` on `InvoiceStatus` returning the allowed next states, and `transitionTo()` on `Invoice` that:
+- returns a new `Invoice` with the updated status if the transition is valid,
+- returns `null` if the transition is forbidden.
+
+Valid transitions:
+- `Draft` → `Sent`
+- `Sent` → `Paid` or `Cancelled`
+- `Paid` and `Cancelled` are terminal (no transitions)
+MD,
+                'boilerplate_code' => <<<'PHP'
+<?php
+
+enum InvoiceStatus: string
+{
+    case Draft     = 'draft';
+    case Sent      = 'sent';
+    case Paid      = 'paid';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function transitions(): array
+    {
+        // TODO: return allowed next states for each case
+    }
+}
+
+class Invoice
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly InvoiceStatus $status,
+    ) {}
+
+    public function transitionTo(InvoiceStatus $next): ?static
+    {
+        // TODO: return a new Invoice with $next status if allowed,
+        // or null if the transition is forbidden
+    }
+}
+PHP,
+                'tests_code' => <<<'PHP'
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class StateMachineTest extends TestCase
+{
+    public function test_draft_can_transition_to_sent(): void
+    {
+        $invoice = new Invoice(1, InvoiceStatus::Draft);
+        $next    = $invoice->transitionTo(InvoiceStatus::Sent);
+        $this->assertNotNull($next);
+        $this->assertSame(InvoiceStatus::Sent, $next->status);
+    }
+
+    public function test_draft_cannot_transition_to_paid(): void
+    {
+        $invoice = new Invoice(1, InvoiceStatus::Draft);
+        $this->assertNull($invoice->transitionTo(InvoiceStatus::Paid));
+    }
+
+    public function test_sent_can_transition_to_paid_or_cancelled(): void
+    {
+        $invoice = new Invoice(2, InvoiceStatus::Sent);
+        $this->assertNotNull($invoice->transitionTo(InvoiceStatus::Paid));
+        $this->assertNotNull($invoice->transitionTo(InvoiceStatus::Cancelled));
+    }
+
+    public function test_paid_is_terminal(): void
+    {
+        $invoice = new Invoice(3, InvoiceStatus::Paid);
+        $this->assertNull($invoice->transitionTo(InvoiceStatus::Cancelled));
+    }
+
+    public function test_transition_preserves_id(): void
+    {
+        $invoice = new Invoice(42, InvoiceStatus::Draft);
+        $next    = $invoice->transitionTo(InvoiceStatus::Sent);
+        $this->assertSame(42, $next->id);
+    }
+}
+PHP,
+                'is_premium' => true,
+                'price_eur' => 990,
+            ],
+        ];
+
+        foreach ($challenges as $data) {
+            Challenge::create([...$data, 'created_by' => $admin->id]);
+        }
+    }
+}

--- a/frontend/app/middleware/auth.ts
+++ b/frontend/app/middleware/auth.ts
@@ -4,4 +4,8 @@ export default defineNuxtRouteMiddleware((to, from) => {
     if (!user.value) {
         return navigateTo('/login')
     }
+
+    if (user.value.needs_onboarding && to.path !== '/onboarding') {
+        return navigateTo('/onboarding')
+    }
 })

--- a/frontend/app/pages/onboarding.vue
+++ b/frontend/app/pages/onboarding.vue
@@ -1,527 +1,463 @@
 <template>
-  <div class="onboarding-page">
-    <div class="onboarding-card">
+  <NuxtLayout name="default">
+    <div class="relative -mx-4 -mt-4 min-h-screen overflow-hidden bg-gray-950 px-4 py-10 sm:-mx-8 sm:-mt-8 sm:px-8">
 
-      <!-- Header -->
-      <div class="card-header">
-        <NuxtLink to="/" class="logo-link">
-          <img src="/images/codecv.png" alt="CODECV" class="logo" onerror="this.style.display='none'" />
-        </NuxtLink>
-        <h1>Welcome, {{ user?.fullname?.split(' ')[0] }}!</h1>
-        <p>Help us personalise your experience — takes 60 seconds.</p>
+      <!-- Ambient glow -->
+      <div class="pointer-events-none absolute inset-0 overflow-hidden">
+        <div class="absolute -top-40 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-emerald-500/10 blur-3xl" />
+        <div class="absolute top-1/3 -left-20 h-60 w-60 rounded-full bg-emerald-600/5 blur-3xl" />
+        <div class="absolute top-1/3 -right-20 h-60 w-60 rounded-full bg-emerald-600/5 blur-3xl" />
       </div>
 
-      <!-- Step indicator -->
-      <div class="steps">
-        <div v-for="i in 3" :key="i" class="step-item">
-          <div class="step-circle" :class="stepClass(i)">
-            <UIcon v-if="i < step" name="i-heroicons-check" class="h-3.5 w-3.5" />
-            <span v-else>{{ i }}</span>
-          </div>
-          <div v-if="i < 3" class="step-line" :class="i < step ? 'step-line--done' : ''" />
-        </div>
-      </div>
+      <div class="relative mx-auto max-w-3xl">
 
-      <!-- ── STEP 1 — Your profile ──────────────────────────── -->
-      <Transition :name="transitionName" mode="out-in">
-        <div v-if="step === 1" key="1" class="step-body">
-          <h2 class="step-title">Your profile</h2>
-
-          <div class="field">
-            <label>Current role</label>
-            <div class="field__wrap">
-              <UIcon name="i-heroicons-briefcase" class="field__ico" />
-              <select v-model="form.profession" required>
-                <option value="" disabled>Select your role…</option>
-                <optgroup label="Development">
-                  <option>Frontend Developer</option>
-                  <option>Backend Developer</option>
-                  <option>Full-Stack Developer</option>
-                  <option>Mobile Developer</option>
-                  <option>DevOps / Platform Engineer</option>
-                  <option>Data Engineer</option>
-                  <option>Machine Learning Engineer</option>
-                </optgroup>
-                <optgroup label="Other IT">
-                  <option>QA / Test Engineer</option>
-                  <option>Cloud Architect</option>
-                  <option>Security Engineer</option>
-                  <option>IT Manager / Tech Lead</option>
-                  <option>Product Manager</option>
-                  <option>UX / UI Designer</option>
-                </optgroup>
-                <optgroup label="Status">
-                  <option>Student / Bootcamp</option>
-                  <option>Career Changer</option>
-                  <option>Freelancer / Consultant</option>
-                  <option>Other</option>
-                </optgroup>
-              </select>
-            </div>
-          </div>
-
-          <div class="field">
-            <label>Experience level</label>
-            <div class="card-grid">
-              <button
-                v-for="opt in levelOptions" :key="opt.value" type="button"
-                class="option-card" :class="form.level === opt.value ? 'option-card--active' : ''"
-                @click="form.level = opt.value"
+        <!-- Step indicator -->
+        <div class="mb-12 flex items-start justify-center gap-0">
+          <template v-for="(meta, i) in stepMeta" :key="i">
+            <div class="flex flex-col items-center">
+              <div
+                :class="[
+                  'flex h-9 w-9 items-center justify-center rounded-full border-2 text-sm font-bold transition-all duration-300',
+                  i + 1 < step  ? 'border-emerald-500 bg-emerald-500 text-white' :
+                  i + 1 === step ? 'border-emerald-400 bg-emerald-400/10 text-emerald-400' :
+                                   'border-gray-700 bg-gray-900 text-gray-600',
+                ]"
               >
-                <span class="option-card__icon">{{ opt.icon }}</span>
-                <span class="option-card__label">{{ opt.label }}</span>
-                <span class="option-card__sub">{{ opt.sub }}</span>
-              </button>
-            </div>
-          </div>
-
-          <div class="step-actions">
-            <button class="btn-primary" :disabled="!step1Valid" @click="next">
-              Continue <UIcon name="i-heroicons-arrow-right" class="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-      </Transition>
-
-      <!-- ── STEP 2 — What you're looking for ──────────────── -->
-      <Transition :name="transitionName" mode="out-in">
-        <div v-if="step === 2" key="2" class="step-body">
-          <h2 class="step-title">What are you looking for?</h2>
-
-          <div class="field">
-            <label>Choose the product that fits your goal</label>
-            <div class="product-grid">
-              <button
-                v-for="opt in productOptions" :key="opt.value" type="button"
-                class="product-card" :class="form.product_interest === opt.value ? 'product-card--active' : ''"
-                @click="form.product_interest = opt.value"
+                <UIcon v-if="i + 1 < step" name="i-heroicons-check-20-solid" class="h-4 w-4" />
+                <span v-else>{{ i + 1 }}</span>
+              </div>
+              <span
+                class="mt-2 hidden text-xs sm:block"
+                :class="i + 1 === step ? 'font-semibold text-white' : i + 1 < step ? 'text-emerald-500' : 'text-gray-600'"
               >
-                <span class="product-card__icon">{{ opt.icon }}</span>
-                <p class="product-card__label">{{ opt.label }}</p>
-                <p class="product-card__desc">{{ opt.desc }}</p>
-                <p class="product-card__price">{{ opt.price }}</p>
-              </button>
-            </div>
-          </div>
-
-          <div class="field">
-            <label>When do you want to see results?</label>
-            <div class="tag-row">
-              <button
-                v-for="opt in timelineOptions" :key="opt.value" type="button"
-                class="tag-btn" :class="form.timeline === opt.value ? 'tag-btn--active' : ''"
-                @click="form.timeline = opt.value"
-              >{{ opt.label }}</button>
-            </div>
-          </div>
-
-          <div class="step-actions">
-            <button class="btn-ghost" @click="prev">
-              <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" /> Back
-            </button>
-            <button class="btn-primary" :disabled="!step2Valid" @click="next">
-              Continue <UIcon name="i-heroicons-arrow-right" class="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-      </Transition>
-
-      <!-- ── STEP 3 — Your situation ───────────────────────── -->
-      <Transition :name="transitionName" mode="out-in">
-        <div v-if="step === 3" key="3" class="step-body">
-          <h2 class="step-title">Your situation</h2>
-
-          <div class="field">
-            <label>Main stack <span class="label-hint">(select all that apply)</span></label>
-            <div class="tag-row tag-row--wrap">
-              <button
-                v-for="s in stackOptions" :key="s" type="button"
-                class="tag-btn" :class="form.stack.includes(s) ? 'tag-btn--active' : ''"
-                @click="toggleStack(s)"
-              >{{ s }}</button>
-            </div>
-          </div>
-
-          <div class="field">
-            <label>Hours available per week</label>
-            <div class="tag-row">
-              <button
-                v-for="opt in availabilityOptions" :key="opt.value" type="button"
-                class="tag-btn" :class="form.availability_hours === opt.value ? 'tag-btn--active' : ''"
-                @click="form.availability_hours = opt.value"
-              >{{ opt.label }}</button>
-            </div>
-          </div>
-
-          <div class="field">
-            <label>Anything else you'd like us to know? <span class="label-hint">(optional)</span></label>
-            <div class="field__wrap field__wrap--textarea">
-              <textarea
-                v-model="form.goal" rows="3" maxlength="500"
-                placeholder="Your current situation, specific challenges, what you've tried before…"
-              ></textarea>
-              <span class="char-count">{{ form.goal.length }}/500</span>
-            </div>
-          </div>
-
-          <Transition name="err">
-            <div v-if="error" class="alert" role="alert">
-              <UIcon name="i-heroicons-exclamation-circle" class="alert__ico" />
-              {{ error }}
-            </div>
-          </Transition>
-
-          <div class="step-actions">
-            <button class="btn-ghost" @click="prev">
-              <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" /> Back
-            </button>
-            <button class="btn-primary" :disabled="loading || !step3Valid" @click="handleSubmit">
-              <span v-if="!loading">Complete setup</span>
-              <span v-else class="spinner-row">
-                <svg viewBox="0 0 24 24" fill="none">
-                  <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3"
-                    stroke-dasharray="40 20" stroke-linecap="round"
-                    style="transform-origin:center;animation:spin .8s linear infinite"/>
-                </svg>
-                Saving…
+                {{ meta.stepLabel }}
               </span>
-            </button>
-          </div>
-
-          <button type="button" class="btn-skip" @click="navigateTo('/dashboard')">
-            Skip for now
-          </button>
+            </div>
+            <div
+              v-if="i < stepMeta.length - 1"
+              class="mx-1 mt-4 h-px w-16 transition-all duration-500 sm:w-24"
+              :class="i + 1 < step ? 'bg-emerald-500' : 'bg-gray-800'"
+            />
+          </template>
         </div>
-      </Transition>
 
+        <!-- Step heading -->
+        <Transition name="fade" mode="out-in">
+          <div :key="`h-${step}`" class="mb-8 text-center">
+            <p class="mb-1 text-xs font-semibold uppercase tracking-widest text-emerald-500">
+              Step {{ step }} of {{ TOTAL_STEPS }}
+            </p>
+            <h1 class="text-4xl font-black tracking-tight text-white sm:text-5xl">
+              {{ stepMeta[step - 1].title }}
+            </h1>
+            <p class="mt-3 text-base text-gray-400">{{ stepMeta[step - 1].subtitle }}</p>
+          </div>
+        </Transition>
+
+        <!-- Step content -->
+        <Transition name="slide" mode="out-in">
+          <div :key="`c-${step}`">
+
+            <!-- STEP 1 — Background -->
+            <div v-if="step === 1" class="space-y-6">
+              <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 backdrop-blur-sm">
+                <label class="mb-2 block text-sm font-semibold text-gray-300">Current Role <span class="text-emerald-500">*</span></label>
+                <UInput
+                  v-model="form.profession"
+                  placeholder="e.g. Frontend Developer, DevOps Engineer…"
+                  size="xl"
+                  :ui="{ base: 'bg-gray-800 border-gray-700 text-white placeholder-gray-600 focus:border-emerald-500' }"
+                />
+              </div>
+
+              <div>
+                <label class="mb-3 block text-sm font-semibold text-gray-300">Experience Level <span class="text-emerald-500">*</span></label>
+                <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  <button
+                    v-for="opt in levelOptions"
+                    :key="opt.value"
+                    type="button"
+                    :class="[
+                      'group rounded-2xl border p-5 text-left transition-all duration-200',
+                      form.level === opt.value
+                        ? 'border-emerald-500 bg-emerald-950/50 ring-1 ring-emerald-500/30'
+                        : 'border-gray-800 bg-gray-900/60 hover:border-gray-600 hover:bg-gray-800/80',
+                    ]"
+                    @click="form.level = opt.value"
+                  >
+                    <p class="text-sm font-bold" :class="form.level === opt.value ? 'text-emerald-400' : 'text-white'">{{ opt.label }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ opt.sub }}</p>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- STEP 2 — Career Goal -->
+            <div v-else-if="step === 2" class="space-y-6">
+              <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 backdrop-blur-sm">
+                <label class="mb-2 block text-sm font-semibold text-gray-300">What do you want to achieve? <span class="text-emerald-500">*</span></label>
+                <UTextarea
+                  v-model="form.goal"
+                  placeholder="e.g. Land a senior full-stack role at a product company in Ireland within 12 months…"
+                  :rows="4"
+                  autoresize
+                  maxlength="255"
+                  :ui="{ base: 'bg-gray-800 border-gray-700 text-white placeholder-gray-600 focus:border-emerald-500' }"
+                />
+                <p class="mt-2 text-xs text-gray-600">Your consultant will use this to build your personal learning plan.</p>
+              </div>
+
+              <div>
+                <label class="mb-3 block text-sm font-semibold text-gray-300">Target Timeline <span class="text-emerald-500">*</span></label>
+                <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  <button
+                    v-for="opt in timelineOptions"
+                    :key="opt.value"
+                    type="button"
+                    :class="[
+                      'rounded-2xl border p-5 text-left transition-all duration-200',
+                      form.timeline === opt.value
+                        ? 'border-emerald-500 bg-emerald-950/50 ring-1 ring-emerald-500/30'
+                        : 'border-gray-800 bg-gray-900/60 hover:border-gray-600 hover:bg-gray-800/80',
+                    ]"
+                    @click="form.timeline = opt.value"
+                  >
+                    <p class="text-sm font-bold" :class="form.timeline === opt.value ? 'text-emerald-400' : 'text-white'">{{ opt.label }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ opt.sub }}</p>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- STEP 3 — Stack & Availability -->
+            <div v-else-if="step === 3" class="space-y-6">
+              <div class="rounded-2xl border border-gray-800 bg-gray-900/60 p-6 backdrop-blur-sm">
+                <label class="mb-1 block text-sm font-semibold text-gray-300">
+                  Your Tech Stack <span class="text-emerald-500">*</span>
+                </label>
+                <p class="mb-4 text-xs text-gray-600">Select technologies you work with or want to master.</p>
+
+                <div v-if="form.stack.length" class="mb-4 flex flex-wrap gap-2">
+                  <span
+                    v-for="tag in form.stack"
+                    :key="tag"
+                    class="flex items-center gap-1.5 rounded-full bg-emerald-500/15 px-3 py-1 text-xs font-semibold text-emerald-400 ring-1 ring-emerald-500/30"
+                  >
+                    {{ tag }}
+                    <button type="button" class="leading-none text-emerald-600 hover:text-emerald-300" @click="removeTag(tag)">×</button>
+                  </span>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                  <button
+                    v-for="tag in popularTags"
+                    :key="tag"
+                    type="button"
+                    :class="[
+                      'rounded-full px-3 py-1.5 text-xs font-medium transition-all duration-150',
+                      form.stack.includes(tag)
+                        ? 'bg-emerald-500/20 text-emerald-400 ring-1 ring-emerald-500/40'
+                        : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200',
+                    ]"
+                    @click="toggleTag(tag)"
+                  >
+                    {{ tag }}
+                  </button>
+                </div>
+
+                <div class="mt-4 flex gap-2">
+                  <UInput
+                    v-model="customTag"
+                    placeholder="Add another…"
+                    size="sm"
+                    class="flex-1"
+                    :ui="{ base: 'bg-gray-800 border-gray-700 text-white placeholder-gray-600 focus:border-emerald-500' }"
+                    @keydown.enter.prevent="addCustomTag"
+                  />
+                  <UButton size="sm" color="gray" variant="outline" @click="addCustomTag">Add</UButton>
+                </div>
+              </div>
+
+              <div>
+                <label class="mb-3 block text-sm font-semibold text-gray-300">Weekly Availability <span class="text-emerald-500">*</span></label>
+                <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  <button
+                    v-for="opt in availabilityOptions"
+                    :key="opt.value"
+                    type="button"
+                    :class="[
+                      'rounded-2xl border p-5 text-left transition-all duration-200',
+                      form.availability_hours === opt.value
+                        ? 'border-emerald-500 bg-emerald-950/50 ring-1 ring-emerald-500/30'
+                        : 'border-gray-800 bg-gray-900/60 hover:border-gray-600 hover:bg-gray-800/80',
+                    ]"
+                    @click="form.availability_hours = opt.value"
+                  >
+                    <p class="text-sm font-bold" :class="form.availability_hours === opt.value ? 'text-emerald-400' : 'text-white'">{{ opt.label }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ opt.sub }}</p>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- STEP 4 — Learning Style (vocational) -->
+            <div v-else-if="step === 4" class="space-y-4">
+              <p class="text-sm text-gray-500">
+                Every career journey is different. Choose the path that matches the way you grow best.
+              </p>
+
+              <div class="grid gap-4 sm:grid-cols-3">
+                <button
+                  v-for="opt in productOptions"
+                  :key="opt.value"
+                  type="button"
+                  :class="[
+                    'group relative overflow-hidden rounded-2xl border p-6 text-left transition-all duration-300',
+                    form.product_interest === opt.value
+                      ? 'border-emerald-500 bg-emerald-950/50 ring-1 ring-emerald-500/30'
+                      : 'border-gray-800 bg-gray-900/60 hover:border-gray-600 hover:bg-gray-800/70',
+                  ]"
+                  @click="form.product_interest = opt.value"
+                >
+                  <!-- Glow on selected -->
+                  <div
+                    v-if="form.product_interest === opt.value"
+                    class="pointer-events-none absolute -top-8 left-1/2 h-24 w-24 -translate-x-1/2 rounded-full bg-emerald-500/20 blur-2xl"
+                  />
+
+                  <div class="relative">
+                    <div class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl" :class="opt.iconBg">
+                      <UIcon :name="opt.icon" class="h-6 w-6" :class="opt.iconColor" />
+                    </div>
+                    <p class="font-bold text-white">{{ opt.label }}</p>
+                    <p class="mt-2 text-xs leading-relaxed text-gray-500">{{ opt.description }}</p>
+                    <div
+                      v-if="form.product_interest === opt.value"
+                      class="mt-4 flex items-center gap-1 text-xs font-semibold text-emerald-400"
+                    >
+                      <UIcon name="i-heroicons-check-circle-20-solid" class="h-4 w-4" />
+                      Selected
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+          </div>
+        </Transition>
+
+        <!-- Navigation -->
+        <div class="mt-8 flex items-center justify-between">
+          <UButton
+            v-if="step > 1"
+            color="gray"
+            variant="ghost"
+            icon="i-heroicons-arrow-left"
+            class="text-gray-400 hover:text-white"
+            @click="step--"
+          >
+            Back
+          </UButton>
+          <div v-else />
+
+          <UButton
+            v-if="step < TOTAL_STEPS"
+            size="lg"
+            :disabled="!stepValid"
+            :class="[
+              'rounded-xl px-8 font-semibold transition-all',
+              stepValid
+                ? 'bg-emerald-500 text-white hover:bg-emerald-400'
+                : 'cursor-not-allowed bg-gray-800 text-gray-600',
+            ]"
+            @click="nextStep"
+          >
+            Continue
+            <template #trailing>
+              <UIcon name="i-heroicons-arrow-right" class="h-4 w-4" />
+            </template>
+          </UButton>
+
+          <UButton
+            v-else
+            size="lg"
+            :loading="loading"
+            :disabled="!stepValid"
+            :class="[
+              'rounded-xl px-8 font-semibold transition-all',
+              stepValid
+                ? 'bg-emerald-500 text-white hover:bg-emerald-400'
+                : 'cursor-not-allowed bg-gray-800 text-gray-600',
+            ]"
+            @click="submit"
+          >
+            Complete Assessment
+          </UButton>
+        </div>
+
+      </div>
     </div>
-  </div>
+  </NuxtLayout>
 </template>
 
 <script setup lang="ts">
-definePageMeta({ layout: false, middleware: 'auth' })
-useHead({ title: 'Welcome — CODECV' })
+import type { User } from '~/types/models'
 
-const { user, updateUser } = useAuth()
+definePageMeta({ layout: false, middleware: 'auth' })
+
+const TOTAL_STEPS = 4
+
+const { user } = useAuth()
 const { patch } = useApi()
 
-const step           = ref(1)
-const transitionName = ref('slide-left')
-const loading        = ref(false)
-const error          = ref('')
+const step = ref(1)
+const loading = ref(false)
+const customTag = ref('')
 
 const form = reactive({
-  profession:         '',
-  level:              '' as string,
-  stack:              [] as string[],
-  product_interest:   '' as string,
-  availability_hours: null as number | null,
-  timeline:           '' as string,
-  goal:               '',
+  profession: '',
+  level: '' as '' | 'junior' | 'mid' | 'senior' | 'manager',
+  goal: '',
+  timeline: '' as '' | '1-3m' | '3-6m' | '6-12m' | 'flexible',
+  availability_hours: 0,
+  stack: [] as string[],
+  product_interest: '' as '' | 'self-serve' | 'bootcamp' | 'mentorship',
 })
 
-// ── Options ────────────────────────────────────────────────
+const stepMeta = [
+  { stepLabel: 'Background',   title: 'Where are you today?',          subtitle: 'Tell us about your current role and level of experience.' },
+  { stepLabel: 'Goal',         title: 'Where do you want to go?',      subtitle: 'Define your career goal and the timeline you\'re working with.' },
+  { stepLabel: 'Stack',        title: 'What do you work with?',        subtitle: 'Select your technologies and how much time you can commit each week.' },
+  { stepLabel: 'Style',        title: 'How do you grow best?',         subtitle: 'Choose the type of support that fits your learning style.' },
+]
+
 const levelOptions = [
-  { value: 'junior',  icon: '🌱', label: 'Júnior',  sub: '0–2 years' },
-  { value: 'mid',     icon: '⚡', label: 'Pleno',   sub: '2–5 years' },
-  { value: 'senior',  icon: '🚀', label: 'Sênior',  sub: '5+ years'  },
-  { value: 'manager', icon: '🎯', label: 'Manager', sub: 'Tech Lead / Manager' },
+  { value: 'junior',  label: 'Junior',    sub: '< 2 years' },
+  { value: 'mid',     label: 'Mid-Level', sub: '2–5 years' },
+  { value: 'senior',  label: 'Senior',    sub: '5+ years' },
+  { value: 'manager', label: 'Manager',   sub: 'Tech lead / EM' },
+]
+
+const timelineOptions = [
+  { value: '1-3m',     label: '1–3 months',  sub: 'Moving fast' },
+  { value: '3-6m',     label: '3–6 months',  sub: 'Steady pace' },
+  { value: '6-12m',    label: '6–12 months', sub: 'Thorough' },
+  { value: 'flexible', label: 'Flexible',    sub: 'No rush' },
+]
+
+const availabilityOptions = [
+  { value: 5,  label: '~5 h/week',  sub: 'Light commitment' },
+  { value: 10, label: '~10 h/week', sub: 'Regular practice' },
+  { value: 20, label: '~20 h/week', sub: 'Serious effort' },
+  { value: 40, label: '40+ h/week', sub: 'Full focus' },
 ]
 
 const productOptions = [
   {
     value: 'self-serve',
-    icon:  '📄',
-    label: 'Career Accelerator',
-    desc:  'CV review, LinkedIn optimisation, interview prep',
-    price: 'From €99/month',
+    label: 'Self-Directed',
+    description: 'I learn best independently. Give me the tools, resources, and a clear roadmap — I\'ll take it from there.',
+    icon: 'i-heroicons-book-open',
+    iconBg: 'bg-blue-500/10',
+    iconColor: 'text-blue-400',
   },
   {
     value: 'bootcamp',
-    icon:  '🧑‍💻',
-    label: 'Laravel Bootcamp',
-    desc:  'Laravel + New Relic · 12–16 weeks · cohort-based',
-    price: '€2,500–5,000',
+    label: 'Structured Programme',
+    description: 'I thrive with a defined curriculum, milestones, and clear goals to keep me on track.',
+    icon: 'i-heroicons-academic-cap',
+    iconBg: 'bg-emerald-500/10',
+    iconColor: 'text-emerald-400',
   },
   {
     value: 'mentorship',
-    icon:  '🎓',
-    label: '1-on-1 Mentorship',
-    desc:  'Bi-weekly sessions, personalised roadmap',
-    price: '€800–1,500/month',
+    label: 'Personal Mentorship',
+    description: 'I want direct guidance from an expert who understands my goals and challenges me every step of the way.',
+    icon: 'i-heroicons-users',
+    iconBg: 'bg-amber-500/10',
+    iconColor: 'text-amber-400',
   },
 ]
 
-const timelineOptions = [
-  { value: '1-3m',     label: '1–3 months'  },
-  { value: '3-6m',     label: '3–6 months'  },
-  { value: '6-12m',    label: '6–12 months' },
-  { value: 'flexible', label: 'No rush'     },
+const popularTags = [
+  'JavaScript', 'TypeScript', 'Python', 'PHP', 'Java', 'Go', 'C#', 'Ruby', 'Rust', 'Swift',
+  'React', 'Vue', 'Angular', 'Next.js', 'Nuxt', 'Svelte',
+  'Node.js', 'Laravel', 'Django', 'Spring Boot', 'Rails',
+  'PostgreSQL', 'MySQL', 'MongoDB', 'Redis',
+  'AWS', 'GCP', 'Azure', 'Docker', 'Kubernetes', 'Linux',
 ]
 
-const stackOptions = [
-  'Laravel/PHP', 'React', 'Vue.js', 'Node.js',
-  'TypeScript', 'Python', 'DevOps/Cloud', 'Mobile',
-  'Java/Spring', 'Other',
-]
+const stepValid = computed(() => {
+  if (step.value === 1) return form.profession.trim().length > 0 && form.level !== ''
+  if (step.value === 2) return form.goal.trim().length > 0 && form.timeline !== ''
+  if (step.value === 3) return form.stack.length > 0 && form.availability_hours > 0
+  if (step.value === 4) return form.product_interest !== ''
+  return false
+})
 
-const availabilityOptions = [
-  { value: 5,  label: '~5h/week'  },
-  { value: 10, label: '~10h/week' },
-  { value: 20, label: '~20h/week' },
-  { value: 40, label: '40h+ week' },
-]
-
-// ── Validation ─────────────────────────────────────────────
-const step1Valid = computed(() => form.profession && form.level)
-const step2Valid = computed(() => form.product_interest && form.timeline)
-const step3Valid = computed(() => form.stack.length > 0 && form.availability_hours !== null)
-
-// ── Navigation ─────────────────────────────────────────────
-function next() {
-  transitionName.value = 'slide-left'
-  step.value++
-}
-function prev() {
-  transitionName.value = 'slide-right'
-  step.value--
-}
-
-function stepClass(i: number) {
-  if (i < step.value)  return 'step-circle--done'
-  if (i === step.value) return 'step-circle--active'
-  return ''
-}
-
-function toggleStack(s: string) {
-  const idx = form.stack.indexOf(s)
-  if (idx === -1) form.stack.push(s)
+function toggleTag(tag: string) {
+  const idx = form.stack.indexOf(tag)
+  if (idx === -1) form.stack.push(tag)
   else form.stack.splice(idx, 1)
 }
 
-// ── Submit ──────────────────────────────────────────────────
-async function handleSubmit() {
+function removeTag(tag: string) {
+  form.stack.splice(form.stack.indexOf(tag), 1)
+}
+
+function addCustomTag() {
+  const t = customTag.value.trim()
+  if (t && !form.stack.includes(t)) form.stack.push(t)
+  customTag.value = ''
+}
+
+function nextStep() {
+  if (stepValid.value) step.value++
+}
+
+async function submit() {
+  if (!stepValid.value) return
   loading.value = true
-  error.value   = ''
   try {
-    const res = await patch<{ message: string; user: any }>('/me/onboarding', { ...form })
-    updateUser(res.user)
-    navigateTo('/dashboard')
-  } catch (e: any) {
-    error.value = e?.data?.message || 'Something went wrong. Please try again.'
+    const res = await patch<{ message: string; user: User }>('/me/onboarding', {
+      profession: form.profession,
+      level: form.level,
+      goal: form.goal,
+      timeline: form.timeline,
+      availability_hours: form.availability_hours,
+      stack: form.stack,
+      product_interest: form.product_interest,
+    })
+    if (user.value) Object.assign(user.value, res.user)
+    await navigateTo('/dashboard')
   } finally {
     loading.value = false
   }
 }
+
+useHead({ title: 'Career Assessment — CODECV' })
 </script>
 
 <style scoped>
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-.onboarding-page {
-  --accent:  #6366f1;
-  --glow:    rgba(99,102,241,0.18);
-  --error:   #ef4444;
-  --font:    'Inter', system-ui, sans-serif;
-  --ease:    cubic-bezier(0.16,1,0.3,1);
-  font-family: var(--font);
-  min-height: 100dvh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem 1rem;
-  background: linear-gradient(135deg, #f0f4ff 0%, #e8f4f8 100%);
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
 }
 
-.onboarding-card {
-  width: 100%;
-  max-width: 580px;
-  background: #fff;
-  border-radius: 20px;
-  padding: 2.5rem;
-  box-shadow: 0 20px 60px rgba(0,0,0,0.1), 0 4px 16px rgba(0,0,0,0.05);
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.25s ease;
 }
-
-/* Header */
-.card-header { text-align: center; margin-bottom: 1.75rem; }
-.logo-link { display: inline-block; margin-bottom: 1rem; }
-.logo { height: 44px; width: auto; mix-blend-mode: multiply; }
-.card-header h1 { font-size: 1.5rem; font-weight: 800; color: #0f172a; letter-spacing: -0.02em; margin-bottom: 0.35rem; }
-.card-header p  { font-size: 0.875rem; color: #64748b; }
-
-/* Step indicator */
-.steps {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  margin-bottom: 2rem;
+.slide-enter-from {
+  opacity: 0;
+  transform: translateY(12px);
 }
-.step-item { display: flex; align-items: center; }
-.step-circle {
-  width: 28px; height: 28px; border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 0.75rem; font-weight: 700;
-  background: #f1f5f9; color: #94a3b8;
-  border: 2px solid #e2e8f0;
-  transition: all .25s var(--ease);
-}
-.step-circle--active {
-  background: var(--accent); color: #fff; border-color: var(--accent);
-  box-shadow: 0 0 0 4px rgba(99,102,241,0.15);
-}
-.step-circle--done { background: #10b981; color: #fff; border-color: #10b981; }
-.step-line {
-  width: 48px; height: 2px;
-  background: #e2e8f0; transition: background .25s;
-}
-.step-line--done { background: #10b981; }
-
-/* Step body */
-.step-body { animation: rise .35s var(--ease) both; }
-@keyframes rise { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
-
-.step-title {
-  font-size: 1.1rem; font-weight: 700; color: #0f172a;
-  margin-bottom: 1.5rem;
-}
-
-/* Fields */
-.field { margin-bottom: 1.5rem; }
-.field label {
-  display: block; font-size: 0.82rem; font-weight: 600;
-  color: #374151; margin-bottom: 0.6rem;
-}
-.label-hint { font-weight: 400; color: #94a3b8; }
-.field__wrap { position: relative; }
-.field__ico {
-  position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%);
-  width: 16px; height: 16px; color: #9ca3af; pointer-events: none;
-}
-
-select {
-  width: 100%; background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 10px;
-  padding: 0.8rem 0.9rem 0.8rem 2.6rem; font-family: var(--font); font-size: 0.9375rem;
-  color: #0f172a; outline: none; cursor: pointer; appearance: none;
-  transition: border-color .15s, box-shadow .15s;
-}
-select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--glow); background: #fff; }
-
-/* Level cards */
-.card-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.6rem; }
-.option-card {
-  display: flex; flex-direction: column; align-items: center; gap: 0.2rem;
-  padding: 0.9rem 0.5rem; border-radius: 10px; border: 1.5px solid #e2e8f0;
-  background: #f8fafc; cursor: pointer; transition: all .15s;
-  font-family: var(--font);
-}
-.option-card:hover { border-color: #a5b4fc; background: #eef2ff; }
-.option-card--active { border-color: var(--accent); background: #eef2ff; box-shadow: 0 0 0 3px var(--glow); }
-.option-card__icon  { font-size: 1.4rem; }
-.option-card__label { font-size: 0.8rem; font-weight: 700; color: #0f172a; }
-.option-card__sub   { font-size: 0.65rem; color: #94a3b8; text-align: center; }
-
-/* Product cards */
-.product-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.75rem; }
-.product-card {
-  display: flex; flex-direction: column; align-items: flex-start; gap: 0.3rem;
-  padding: 1rem; border-radius: 12px; border: 1.5px solid #e2e8f0;
-  background: #f8fafc; cursor: pointer; transition: all .15s;
-  font-family: var(--font); text-align: left;
-}
-.product-card:hover { border-color: #a5b4fc; background: #eef2ff; }
-.product-card--active { border-color: var(--accent); background: #eef2ff; box-shadow: 0 0 0 3px var(--glow); }
-.product-card__icon  { font-size: 1.5rem; }
-.product-card__label { font-size: 0.82rem; font-weight: 700; color: #0f172a; }
-.product-card__desc  { font-size: 0.7rem; color: #64748b; line-height: 1.4; }
-.product-card__price { font-size: 0.7rem; font-weight: 600; color: var(--accent); margin-top: auto; padding-top: 0.4rem; }
-
-/* Tag buttons */
-.tag-row { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-.tag-row--wrap { }
-.tag-btn {
-  padding: 0.45rem 0.9rem; border-radius: 99px; border: 1.5px solid #e2e8f0;
-  background: #f8fafc; font-family: var(--font); font-size: 0.82rem;
-  font-weight: 500; color: #475569; cursor: pointer; transition: all .15s;
-}
-.tag-btn:hover { border-color: #a5b4fc; color: var(--accent); }
-.tag-btn--active { border-color: var(--accent); background: #eef2ff; color: var(--accent); font-weight: 600; }
-
-/* Textarea */
-.field__wrap--textarea { display: flex; flex-direction: column; }
-textarea {
-  width: 100%; background: #f8fafc; border: 1.5px solid #e2e8f0; border-radius: 10px;
-  padding: 0.8rem; font-family: var(--font); font-size: 0.9375rem;
-  color: #0f172a; outline: none; resize: vertical; min-height: 90px;
-  transition: border-color .15s, box-shadow .15s;
-}
-textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--glow); background: #fff; }
-textarea::placeholder { color: #c0c9d4; }
-.char-count { align-self: flex-end; font-size: 0.7rem; color: #94a3b8; margin-top: 0.25rem; }
-
-/* Actions */
-.step-actions {
-  display: flex; justify-content: flex-end; gap: 0.75rem;
-  margin-top: 1.75rem;
-}
-.btn-primary {
-  display: flex; align-items: center; gap: 0.4rem;
-  padding: 0.75rem 1.5rem; background: var(--accent); color: #fff;
-  font-family: var(--font); font-size: 0.9375rem; font-weight: 700;
-  border: none; border-radius: 10px; cursor: pointer;
-  transition: background .2s, transform .15s, box-shadow .2s;
-}
-.btn-primary:hover:not(:disabled) {
-  background: #047857; transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(99,102,241,0.35);
-}
-.btn-primary:disabled { opacity: 0.45; cursor: not-allowed; }
-.btn-ghost {
-  display: flex; align-items: center; gap: 0.4rem;
-  padding: 0.75rem 1rem; background: none;
-  font-family: var(--font); font-size: 0.875rem; font-weight: 500;
-  color: #64748b; border: 1.5px solid #e2e8f0; border-radius: 10px;
-  cursor: pointer; transition: all .15s;
-}
-.btn-ghost:hover { border-color: #94a3b8; color: #374151; }
-.btn-skip {
-  display: block; width: 100%; margin-top: 0.75rem;
-  padding: 0.6rem; background: none; color: #94a3b8;
-  font-family: var(--font); font-size: 0.8rem;
-  border: none; cursor: pointer; transition: color .15s;
-}
-.btn-skip:hover { color: #64748b; }
-
-/* Alert */
-.alert {
-  display: flex; align-items: center; gap: 0.6rem;
-  padding: 0.75rem 1rem; background: #fef2f2; border: 1px solid #fecaca;
-  border-radius: 10px; font-size: 0.875rem; color: var(--error);
-  margin-bottom: 1rem;
-}
-.alert__ico { width: 15px; height: 15px; flex-shrink: 0; }
-.err-enter-active { animation: errIn .3s var(--ease); }
-@keyframes errIn { from { opacity:0; transform:translateY(-4px); } to { opacity:1; transform:translateY(0); } }
-
-/* Slide transitions */
-.slide-left-enter-active,
-.slide-left-leave-active,
-.slide-right-enter-active,
-.slide-right-leave-active { transition: all .25s var(--ease); }
-
-.slide-left-enter-from  { opacity: 0; transform: translateX(30px); }
-.slide-left-leave-to    { opacity: 0; transform: translateX(-30px); }
-.slide-right-enter-from { opacity: 0; transform: translateX(-30px); }
-.slide-right-leave-to   { opacity: 0; transform: translateX(30px); }
-
-.spinner-row { display: flex; align-items: center; gap: 0.5rem; }
-.spinner-row svg { width: 16px; height: 16px; }
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* Responsive */
-@media (max-width: 500px) {
-  .onboarding-card { padding: 1.75rem 1.25rem; }
-  .card-grid { grid-template-columns: repeat(2, 1fr); }
-  .product-grid { grid-template-columns: 1fr; }
+.slide-leave-to {
+  opacity: 0;
+  transform: translateY(-12px);
 }
 </style>

--- a/frontend/app/types/models.ts
+++ b/frontend/app/types/models.ts
@@ -6,6 +6,7 @@ export interface User {
   email: string
   role?: string
   consultant_id?: number | null
+  needs_onboarding?: boolean
   profile?: Profile
   created_at?: string
   updated_at?: string

--- a/tests/Feature/Api/StripeWebhookTest.php
+++ b/tests/Feature/Api/StripeWebhookTest.php
@@ -53,6 +53,25 @@ class StripeWebhookTest extends TestCase
         $this->assertSame(PaymentStatus::PAID, $payment->status);
         $this->assertSame('pi_test_complete', $payment->stripe_payment_intent_id);
         $this->assertNotNull($payment->paid_at);
+        $this->assertTrue($user->fresh()->needs_onboarding);
+    }
+
+    public function test_checkout_session_completed_for_subscription_marks_payment_paid(): void
+    {
+        $user = User::factory()->create();
+        $payment = $this->makePendingPayment($user, 'cs_test_sub', PaymentTier::MENTORSHIP);
+
+        $event = $this->checkoutCompletedEvent('cs_test_sub');
+        $event['data']['object']['payment_intent'] = null;
+        $event['data']['object']['subscription'] = 'sub_test_123';
+
+        $this->postWebhook($event)->assertOk();
+
+        $payment->refresh();
+        $this->assertSame(PaymentStatus::PAID, $payment->status);
+        $this->assertSame('sub_test_123', $payment->stripe_payment_intent_id);
+        $this->assertNotNull($payment->paid_at);
+        $this->assertTrue($user->fresh()->needs_onboarding);
     }
 
     public function test_async_payment_succeeded_marks_payment_paid(): void
@@ -69,6 +88,7 @@ class StripeWebhookTest extends TestCase
         $payment->refresh();
         $this->assertSame(PaymentStatus::PAID, $payment->status);
         $this->assertSame('pi_test_async', $payment->stripe_payment_intent_id);
+        $this->assertTrue($user->fresh()->needs_onboarding);
     }
 
     public function test_async_payment_failed_marks_payment_failed(): void
@@ -158,12 +178,12 @@ class StripeWebhookTest extends TestCase
         );
     }
 
-    private function makePendingPayment(User $user, string $sessionId): Payment
+    private function makePendingPayment(User $user, string $sessionId, PaymentTier $tier = PaymentTier::ACCELERATOR): Payment
     {
         return Payment::create([
             'user_id' => $user->id,
             'stripe_session_id' => $sessionId,
-            'tier' => PaymentTier::ACCELERATOR,
+            'tier' => $tier,
             'amount' => 9900,
             'currency' => 'eur',
             'status' => PaymentStatus::PENDING,


### PR DESCRIPTION
## Summary

- **Stripe Checkout** — one-time and recurring (subscription) payment sessions; webhook marks payments as PAID and sets `needs_onboarding=true` so users are guided to the career assessment after purchasing
- **Onboarding redesign** — replaced the minimal single-step form with a 4-step dark premium career assessment (role, goal, tech stack, learning style/vocational test); auth middleware auto-redirects users with `needs_onboarding=true`
- **Challenges** — `Challenge` model, `ChallengeDifficulty` enum, migration, and three seed challenges covering PHP 8.x features (null-safe operator, backed enums, state machine)
- **Email verification** — custom API route for SPA-compatible Fortify email verification link
- **CV analysis fixes** — connection timeout handling for Jina AI fetch, raised `job_description` limit to 15 000 chars
- **Marketing frontend** — `.mkt-*` design system, emerald palette, SEO meta via `@nuxtjs/seo`
- **OAuth/auth** — single canonical `APP_FRONTEND_URL` for OAuth callbacks; `FRONTEND_URL` kept as CORS allow-list

## Test plan

- [ ] Complete Stripe checkout flow (one-time ACCELERATOR, recurring MENTORSHIP) and verify webhook marks payment PAID + sets `needs_onboarding=true`
- [ ] Register a new user → confirm redirect to `/onboarding` → complete all 4 steps → confirm redirect to `/dashboard` with `needs_onboarding=false`
- [ ] Run `ddev artisan migrate:fresh --seed` and verify Challenge seeder creates 3 records
- [ ] Upload a CV PDF with `job_url` pointing to a slow/unreachable URL and confirm it returns a graceful error instead of a 500
- [ ] Run full test suite: `ddev artisan test --compact`

🤖 Generated with [Claude Code](https://claude.com/claude-code)