### PR TITLE
fix(frontend): clear TS strict-mode errors across the app

### DIFF
--- a/frontend/app.config.ts
+++ b/frontend/app.config.ts
@@ -1,0 +1,7 @@
+// Nuxt UI v2 reads `ui` from app.config (runtime), not nuxt.config (build).
+export default defineAppConfig({
+  ui: {
+    primary: 'emerald',
+    gray: 'slate',
+  },
+})

--- a/frontend/app/components/AuthBackground.vue
+++ b/frontend/app/components/AuthBackground.vue
@@ -6,8 +6,10 @@
 const canvasRef = ref<HTMLCanvasElement | null>(null)
 
 onMounted(() => {
-  const canvas = canvasRef.value
-  if (!canvas) return
+  const canvasMaybe = canvasRef.value
+  if (!canvasMaybe) return
+  // Bind to a const with non-null type so nested closures keep the narrowing.
+  const canvas: HTMLCanvasElement = canvasMaybe
   const ctx = canvas.getContext('2d')!
   let raf: number
   let angle = 0
@@ -74,7 +76,7 @@ onMounted(() => {
     // Connections between nearby nodes
     for (let i = 0; i < proj.length; i++) {
       for (let j = i + 1; j < proj.length; j++) {
-        const a = proj[i], b = proj[j]
+        const a = proj[i]!, b = proj[j]!
         const dx = a.rx - b.rx, dy = a.ry - b.ry, dz = a.rz - b.rz
         const d  = Math.sqrt(dx * dx + dy * dy + dz * dz)
         if (d < 0.46) {

--- a/frontend/app/components/ChallengeEditor.vue
+++ b/frontend/app/components/ChallengeEditor.vue
@@ -257,28 +257,28 @@ function parseDiff(message: string): AssertionDiff | null {
   let m: RegExpMatchArray | null
 
   m = message.match(/^Failed asserting that (.+) is identical to (.+)\.$/)
-  if (m) return { actual: m[1], expected: m[2] }
+  if (m) return { actual: m[1]!, expected: m[2]! }
 
   m = message.match(/^Failed asserting that (.+) equals (.+)\.$/)
-  if (m) return { actual: m[1], expected: m[2] }
+  if (m) return { actual: m[1]!, expected: m[2]! }
 
   m = message.match(/^Failed asserting that (.+) is greater than (.+)\.$/)
-  if (m) return { actual: m[1], expected: `> ${m[2]}` }
+  if (m) return { actual: m[1]!, expected: `> ${m[2]}` }
 
   m = message.match(/^Failed asserting that (.+) is less than (.+)\.$/)
-  if (m) return { actual: m[1], expected: `< ${m[2]}` }
+  if (m) return { actual: m[1]!, expected: `< ${m[2]}` }
 
   m = message.match(/^Failed asserting that actual size (\d+) matches expected size (\d+)\.$/)
   if (m) return { actual: `count: ${m[1]}`, expected: `count: ${m[2]}` }
 
   m = message.match(/^Failed asserting that (.+) is an instance of (.+)\.$/)
-  if (m) return { actual: m[1], expected: `instanceof ${m[2]}` }
+  if (m) return { actual: m[1]!, expected: `instanceof ${m[2]}` }
 
   m = message.match(/^Failed asserting that array contains (.+)\.$/)
-  if (m) return { actual: '(not in array)', expected: m[1] }
+  if (m) return { actual: '(not in array)', expected: m[1]! }
 
   m = message.match(/^Failed asserting that (.+) is null\.$/)
-  if (m) return { actual: m[1], expected: 'null' }
+  if (m) return { actual: m[1]!, expected: 'null' }
 
   return null
 }

--- a/frontend/app/components/MarkdownContent.vue
+++ b/frontend/app/components/MarkdownContent.vue
@@ -56,7 +56,7 @@ const segments = computed(() => {
     if (match.index > lastIndex) {
       result.push({ type: 'html', content: renderMarkdown(props.content.slice(lastIndex, match.index)) })
     }
-    result.push({ type: match[1] as 'mermaid' | 'lifecycle-diagram', content: match[2].trim() })
+    result.push({ type: match[1] as 'mermaid' | 'lifecycle-diagram', content: (match[2] ?? '').trim() })
     lastIndex = match.index + match[0].length
   }
 

--- a/frontend/app/components/RoadmapFlow.vue
+++ b/frontend/app/components/RoadmapFlow.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script setup lang="ts">
-import { VueFlow, Position } from '@vue-flow/core'
+import { VueFlow, Position, MarkerType } from '@vue-flow/core'
 import { Background } from '@vue-flow/background'
 import { MiniMap } from '@vue-flow/minimap'
 import { Controls } from '@vue-flow/controls'
@@ -66,7 +66,10 @@ const emit  = defineEmits<{ (e: 'nodeClick', step: Step): void }>()
 
 const colorMode = useColorMode()
 const isDark    = computed(() => colorMode.value === 'dark')
-const nodeTypes = { step: markRaw(RoadmapStepNode) }
+// vue-flow's NodeTypesObject expects raw component definitions; markRaw'd
+// SFC imports satisfy the runtime shape but TS sees a stricter generic.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const nodeTypes = { step: markRaw(RoadmapStepNode) } as any
 
 // Snake layout constants
 const NODE_W = 240, NODE_H = 90, V_GAP = 60, H_GAP = 100
@@ -98,7 +101,8 @@ const nodes = computed(() =>
 
 const edges = computed(() =>
   props.steps.slice(0, -1).map((step, i) => {
-    const next   = props.steps[i + 1]
+    // slice(0, -1) guarantees i+1 is always in range.
+    const next   = props.steps[i + 1]!
     const isDone = step.user_status === 'done'
     const isWip  = step.user_status === 'in_progress'
     const stroke = isDone ? '#00AC69' : isWip ? '#00d97e' : 'rgba(0,172,105,0.3)'
@@ -109,7 +113,7 @@ const edges = computed(() =>
       animated:  isWip,
       type:      'smoothstep',
       style:     { stroke, strokeWidth: isDone || isWip ? 2 : 1.5 },
-      markerEnd: { type: 'arrowclosed', color: stroke, width: 11, height: 11 },
+      markerEnd: { type: MarkerType.ArrowClosed, color: stroke, width: 11, height: 11 },
     }
   })
 )

--- a/frontend/app/composables/useApi.ts
+++ b/frontend/app/composables/useApi.ts
@@ -7,7 +7,7 @@ export const useApi = () => {
         const match = document.cookie
             .split('; ')
             .find(row => row.startsWith('XSRF-TOKEN='))
-        return match ? decodeURIComponent(match.split('=')[1]) : undefined
+        return match ? decodeURIComponent(match.split('=')[1] ?? '') : undefined
     }
 
     const getAuthToken = (): string | undefined => {
@@ -57,7 +57,7 @@ export const useApi = () => {
                 credentials: 'include',
                 headers,
                 signal: controller.signal,
-            })
+            }) as T
         } finally {
             clearTimeout(timer)
         }

--- a/frontend/app/composables/useUsers.ts
+++ b/frontend/app/composables/useUsers.ts
@@ -1,32 +1,6 @@
-interface User {
-  id: number
-  fullname: string
-  email: string
-  role: string
-  profile?: {
-    birth_date?: string
-    profession?: string
-    profile_image?: string
-    profile_image_url?: string
-    website?: string
-    github?: string
-    linkedin?: string
-    instagram?: string
-    facebook?: string
-  }
-  created_at: string
-  updated_at: string
-}
+import type { User, PaginatedResponse } from '~/types/models'
 
-interface UsersResponse {
-  data: User[]
-  meta?: {
-    current_page: number
-    last_page: number
-    per_page: number
-    total: number
-  }
-}
+type UsersResponse = PaginatedResponse<User>
 
 export const useUsers = () => {
   const api = useApi()

--- a/frontend/app/layouts/admin.vue
+++ b/frontend/app/layouts/admin.vue
@@ -136,8 +136,8 @@
                     @click="handleNotificationClick(n, close)"
                   >
                     <span class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
-                      :class="notifIconBg(n.data.type)">
-                      <UIcon :name="notifIcon(n.data.type)" class="h-4 w-4" :class="notifIconColor(n.data.type)" />
+                      :class="notifIconBg(String(n.data.type ?? ''))">
+                      <UIcon :name="notifIcon(String(n.data.type ?? ''))" class="h-4 w-4" :class="notifIconColor(String(n.data.type ?? ''))" />
                     </span>
                     <div class="min-w-0 flex-1">
                       <p class="text-[13px] font-medium text-gray-800 dark:text-slate-200 leading-snug">

--- a/frontend/app/layouts/marketing.vue
+++ b/frontend/app/layouts/marketing.vue
@@ -125,7 +125,6 @@
 
 <script setup lang="ts">
 const { isAuthenticated, logout } = useAuth()
-const route = useRoute()
 const mobileOpen = ref(false)
 const scrolled = ref(false)
 // Homepage now uses a light hero — keep the navbar in its light variant,

--- a/frontend/app/pages/dashboard.vue
+++ b/frontend/app/pages/dashboard.vue
@@ -285,7 +285,8 @@ const userColumns = [
   { key: 'actions',    label: '' },
 ]
 
-const roleBadgeColor = (r?: string) => ({ admin: 'red', consultant: 'purple' }[r ?? ''] ?? 'blue')
+const roleBadgeColor = (r?: string): 'red' | 'purple' | 'blue' =>
+  ({ admin: 'red', consultant: 'purple' } as Record<string, 'red' | 'purple'>)[r ?? ''] ?? 'blue'
 const formatDate     = (d: string)  => new Date(d).toLocaleDateString()
 const getUserActions = (u: any) => [[
   { label: 'View', icon: 'i-heroicons-user',   click: () => navigateTo(`/users/${u.id}`) },

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -189,25 +189,25 @@
             </button>
           </div>
 
-          <div class="tabs__panel">
+          <div v-if="activeTabData" class="tabs__panel">
             <div class="tabs__panel-text">
-              <span class="eyebrow">{{ tabs[activeTab].badge }}</span>
-              <h3 class="h3">{{ tabs[activeTab].heading }}</h3>
-              <p>{{ tabs[activeTab].desc }}</p>
+              <span class="eyebrow">{{ activeTabData.badge }}</span>
+              <h3 class="h3">{{ activeTabData.heading }}</h3>
+              <p>{{ activeTabData.desc }}</p>
               <ul class="check-list">
-                <li v-for="b in tabs[activeTab].bullets" :key="b">
+                <li v-for="b in activeTabData.bullets" :key="b">
                   <span class="check-list__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" width="12" height="12" fill="none"><path d="M5 13l4 4L19 7" stroke="#059669" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   </span>
                   {{ b }}
                 </li>
               </ul>
-              <NuxtLink :to="tabs[activeTab].cta" class="btn btn--em-soft">
+              <NuxtLink :to="activeTabData.cta" class="btn btn--em-soft">
                 Learn more →
               </NuxtLink>
             </div>
             <div class="tabs__panel-visual">
-              <img :src="tabs[activeTab].img" :alt="tabs[activeTab].title" />
+              <img :src="activeTabData.img" :alt="activeTabData.title" />
             </div>
           </div>
         </div>
@@ -230,7 +230,7 @@
             class="evercard"
             @mousemove="onVaultMove($event, i)"
             @mouseleave="onVaultLeave(i)"
-            :style="{ '--x': vaultPos[i].x + 'px', '--y': vaultPos[i].y + 'px', '--lit': vaultPos[i].lit }"
+            :style="{ '--x': (vaultPos[i]?.x ?? 0) + 'px', '--y': (vaultPos[i]?.y ?? 0) + 'px', '--lit': vaultPos[i]?.lit ?? 0 }"
           >
             <div class="evercard__pattern" aria-hidden="true"></div>
             <div class="evercard__cross evercard__cross--tl" aria-hidden="true"></div>
@@ -499,6 +499,7 @@ const tabs = [
   },
 ]
 const activeTab = ref(0)
+const activeTabData = computed(() => tabs[activeTab.value])
 
 /* === Evervault cards === */
 const IconBolt = () => h('svg', { viewBox: '0 0 24 24', width: 22, height: 22, fill: 'none' }, [
@@ -520,13 +521,16 @@ const vaultCards = [
 ]
 const vaultPos = reactive(vaultCards.map(() => ({ x: 0, y: 0, lit: 0 })))
 function onVaultMove(e: MouseEvent, i: number) {
+  const pos = vaultPos[i]
+  if (!pos) return
   const rect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-  vaultPos[i].x = e.clientX - rect.left
-  vaultPos[i].y = e.clientY - rect.top
-  vaultPos[i].lit = 1
+  pos.x = e.clientX - rect.left
+  pos.y = e.clientY - rect.top
+  pos.lit = 1
 }
 function onVaultLeave(i: number) {
-  vaultPos[i].lit = 0
+  const pos = vaultPos[i]
+  if (pos) pos.lit = 0
 }
 
 /* === World map === */
@@ -547,28 +551,34 @@ const arcs = computed(() =>
     return `M${x1} ${y1} Q ${cx} ${cy} ${x2} ${y2}`
   })
 )
-// Stylised dotted world map (clusters approximating continents)
+// Stylised dotted world map (clusters approximating continents).
+// Generated with a seeded PRNG so the dot positions are identical on the
+// server and the client — otherwise Vue would log a hydration mismatch
+// and the map would jump on hydrate.
 const mapDots = (() => {
+  let seed = 0x9E3779B1
+  const rand = () => {
+    seed = (seed + 0x6D2B79F5) | 0
+    let t = seed
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
   const dots: number[][] = []
-  const blobs = [
-    // North America
-    [120, 150, 200, 90, 12],
-    // South America
-    [255, 320, 60, 130, 7],
-    // Europe
-    [490, 170, 80, 50, 7],
-    // Africa
-    [540, 290, 80, 140, 9],
-    // Asia
-    [720, 200, 220, 90, 14],
-    // Australia
-    [860, 370, 70, 50, 6],
+  const blobs: Array<[number, number, number, number, number]> = [
+    // [cx, cy, w, h, density]
+    [120, 150, 200, 90, 12],  // North America
+    [255, 320,  60, 130, 7],  // South America
+    [490, 170,  80,  50, 7],  // Europe
+    [540, 290,  80, 140, 9],  // Africa
+    [720, 200, 220,  90, 14], // Asia
+    [860, 370,  70,  50, 6],  // Australia
   ]
   for (const [cx, cy, w, h2, n] of blobs) {
     for (let i = 0; i < n; i++) {
       for (let j = 0; j < (n - 2); j++) {
-        const x = cx + (Math.random() - 0.5) * w
-        const y = cy + (Math.random() - 0.5) * h2
+        const x = cx + (rand() - 0.5) * w
+        const y = cy + (rand() - 0.5) * h2
         const dx = (x - cx) / (w / 2)
         const dy = (y - cy) / (h2 / 2)
         if (dx * dx + dy * dy <= 1.05) dots.push([Math.round(x), Math.round(y)])
@@ -1405,9 +1415,6 @@ function toggleFaq(i: number) { openFaq.value = openFaq.value === i ? null : i }
 @media (max-width: 1024px) {
   .hero__inner { grid-template-columns: 1fr; gap: 56px; }
   .hero__right { min-height: auto; }
-  .hero__photo-stage { max-width: 380px; margin: 0 auto; }
-  .float-card--plan { left: -4%; }
-  .float-card--cv { right: -4%; }
 
   .tabs__panel { grid-template-columns: 1fr; gap: 36px; }
   .vault__grid { grid-template-columns: 1fr 1fr; }
@@ -1417,10 +1424,6 @@ function toggleFaq(i: number) { openFaq.value = openFaq.value === i ? null : i }
 
 @media (max-width: 768px) {
   .hero__metrics { gap: 18px; flex-wrap: wrap; }
-  .hero__photo-stage { max-width: 340px; }
-  .deco--waves { width: 28%; }
-  .deco--net { width: 26%; }
-  .deco--grid { width: 16%; }
 
   .tabs__nav { flex-wrap: wrap; }
   .vault__grid { grid-template-columns: 1fr; }
@@ -1435,7 +1438,5 @@ function toggleFaq(i: number) { openFaq.value = openFaq.value === i ? null : i }
   .row-cta { width: 100%; flex-direction: column; align-items: stretch; }
   .row-cta .btn { width: 100%; }
   .row-cta--center { flex-direction: row; }
-  .float-card { padding: 10px 14px; }
-  .float-card__big { font-size: 1.3rem; }
 }
 </style>

--- a/frontend/app/pages/labs/[id].vue
+++ b/frontend/app/pages/labs/[id].vue
@@ -195,8 +195,9 @@ const router = useRouter()
 const toast  = useToast()
 
 const { fetchStep, updateStepProgress } = usePaths()
+type LabStep = Awaited<ReturnType<typeof fetchStep>>
 
-const step   = ref<any>(null)
+const step   = ref<LabStep | null>(null)
 const loading = ref(true)
 const saving  = ref(false)
 
@@ -241,11 +242,12 @@ const progressPct = computed(() => {
 })
 
 async function markStatus(status: 'in_progress' | 'done') {
-  if (saving.value) return
+  if (saving.value || !step.value) return
   saving.value = true
+  const current = step.value
   try {
-    await updateStepProgress(step.value.id, status)
-    step.value = { ...step.value, user_status: status }
+    await updateStepProgress(current.id, status)
+    step.value = { ...current, user_status: status }
     toast.add({ title: status === 'done' ? 'Step completed!' : 'Marked as in progress', color: 'emerald' })
   } catch {
     toast.add({ title: 'Could not save progress', color: 'red' })
@@ -269,11 +271,11 @@ const typeIcon = computed(() => ({
   reading:   'i-heroicons-book-open',
 }[step.value?.type ?? 'reading']))
 
-const typeBadgeColor = computed(() => ({
-  lab:       'emerald',
-  challenge: 'amber',
-  quiz:      'violet',
-  reading:   'gray',
+const typeBadgeColor = computed((): 'emerald' | 'amber' | 'violet' | 'gray' => ({
+  lab:       'emerald' as const,
+  challenge: 'amber'   as const,
+  quiz:      'violet'  as const,
+  reading:   'gray'    as const,
 }[step.value?.type ?? 'reading']))
 
 const statusLabel = computed(() => ({
@@ -282,9 +284,9 @@ const statusLabel = computed(() => ({
   not_started: 'Not Started',
 }[step.value?.user_status ?? 'not_started']))
 
-const statusColor = computed(() => ({
-  done:        'green',
-  in_progress: 'emerald',
-  not_started: 'gray',
+const statusColor = computed((): 'green' | 'emerald' | 'gray' => ({
+  done:        'green'   as const,
+  in_progress: 'emerald' as const,
+  not_started: 'gray'    as const,
 }[step.value?.user_status ?? 'not_started']))
 </script>

--- a/frontend/app/pages/my-paths.vue
+++ b/frontend/app/pages/my-paths.vue
@@ -98,7 +98,7 @@
           <RoadmapFlow
             v-if="view === 'roadmap' && path.steps.length"
             :steps="path.steps"
-            @node-click="(step) => openStepModal(step, path)"
+            @node-click="(s) => { const full = path.steps.find(x => x.id === s.id); if (full) openStepModal(full, path) }"
           />
 
           <!-- Course content (Udemy-style accordion) -->
@@ -478,12 +478,16 @@ onMounted(async () => {
   }
 })
 
-const enrichedPaths = computed(() =>
+type EnrichedPath = Path & { steps: PathStep[]; doneCount: number; progressPct: number }
+
+const enrichedPaths = computed<EnrichedPath[]>(() =>
   paths.value.map(p => {
     const steps = pathSteps.value[p.id] ?? []
     const doneCount = steps.filter(s => s.user_status === 'done').length
     const progressPct = steps.length ? Math.round((doneCount / steps.length) * 100) : 0
-    return { ...p, steps, doneCount, progressPct }
+    // `paths` is exposed as readonly by the composable; clone via spread and
+    // re-assert as Path so the writable function signatures accept it.
+    return { ...(p as Path), steps, doneCount, progressPct }
   })
 )
 
@@ -535,7 +539,7 @@ async function setStatus(path: Path, step: PathStep, status: PathStep['user_stat
   // optimistic: update this step
   if (arr) {
     const idx = arr.findIndex(s => s.id === step.id)
-    if (idx !== -1) arr[idx] = { ...arr[idx], user_status: status }
+    if (idx !== -1) arr[idx] = { ...arr[idx]!, user_status: status }
   }
 
   try {

--- a/frontend/app/pages/onboarding.vue
+++ b/frontend/app/pages/onboarding.vue
@@ -48,9 +48,9 @@
               Step {{ step }} of {{ TOTAL_STEPS }}
             </p>
             <h1 class="text-4xl font-black tracking-tight text-white sm:text-5xl">
-              {{ stepMeta[step - 1].title }}
+              {{ stepMeta[step - 1]?.title }}
             </h1>
-            <p class="mt-3 text-base text-gray-400">{{ stepMeta[step - 1].subtitle }}</p>
+            <p class="mt-3 text-base text-gray-400">{{ stepMeta[step - 1]?.subtitle }}</p>
           </div>
         </Transition>
 
@@ -329,21 +329,21 @@ const stepMeta = [
   { stepLabel: 'Goal',         title: 'Where do you want to go?',      subtitle: 'Define your career goal and the timeline you\'re working with.' },
   { stepLabel: 'Stack',        title: 'What do you work with?',        subtitle: 'Select your technologies and how much time you can commit each week.' },
   { stepLabel: 'Style',        title: 'How do you grow best?',         subtitle: 'Choose the type of support that fits your learning style.' },
-]
+] as const
 
-const levelOptions = [
+const levelOptions = ([
   { value: 'junior',  label: 'Junior',    sub: '< 2 years' },
   { value: 'mid',     label: 'Mid-Level', sub: '2–5 years' },
   { value: 'senior',  label: 'Senior',    sub: '5+ years' },
   { value: 'manager', label: 'Manager',   sub: 'Tech lead / EM' },
-]
+] as const)
 
-const timelineOptions = [
+const timelineOptions = ([
   { value: '1-3m',     label: '1–3 months',  sub: 'Moving fast' },
   { value: '3-6m',     label: '3–6 months',  sub: 'Steady pace' },
   { value: '6-12m',    label: '6–12 months', sub: 'Thorough' },
   { value: 'flexible', label: 'Flexible',    sub: 'No rush' },
-]
+] as const)
 
 const availabilityOptions = [
   { value: 5,  label: '~5 h/week',  sub: 'Light commitment' },
@@ -352,7 +352,7 @@ const availabilityOptions = [
   { value: 40, label: '40+ h/week', sub: 'Full focus' },
 ]
 
-const productOptions = [
+const productOptions = ([
   {
     value: 'self-serve',
     label: 'Self-Directed',
@@ -377,7 +377,7 @@ const productOptions = [
     iconBg: 'bg-amber-500/10',
     iconColor: 'text-amber-400',
   },
-]
+] as const)
 
 const popularTags = [
   'JavaScript', 'TypeScript', 'Python', 'PHP', 'Java', 'Go', 'C#', 'Ruby', 'Rust', 'Swift',

--- a/frontend/app/pages/paths/[id].vue
+++ b/frontend/app/pages/paths/[id].vue
@@ -52,7 +52,7 @@
           <RoadmapFlow
             v-if="view === 'roadmap' && steps.length"
             :steps="steps"
-            @node-click="openEditStep"
+            @node-click="(s) => { const full = steps.find(x => x.id === s.id); if (full) openEditStep(full) }"
           />
 
           <!-- Empty -->
@@ -265,7 +265,7 @@
           <div>
             <label class="mb-1.5 block text-xs font-semibold text-gray-700 dark:text-gray-300">Linked Course (optional)</label>
             <USelect v-model="form.course_id"
-              :options="[{ label: 'None', value: null }, ...courseOptions]"
+              :options="[{ label: 'None', value: undefined }, ...courseOptions]"
               value-attribute="value"
               option-attribute="label"
               placeholder="Select a course…" />
@@ -327,7 +327,7 @@ const editingStep = ref<PathStep | null>(null)
 const emptyForm = () => ({
   title: '',
   description: '',
-  course_id: null as number | null,
+  course_id: undefined as number | undefined,
   type: 'reading' as 'reading' | 'lab' | 'challenge' | 'quiz',
   lab_url: '',
   instructions: [] as { id: number; text: string }[],
@@ -371,7 +371,10 @@ function stepTypeLabel(type: string) {
 }
 
 function stepTypeBadgeColor(type: string) {
-  return { lab: 'emerald', challenge: 'amber', quiz: 'violet', reading: 'gray' }[type] ?? 'gray'
+  const map: Record<string, 'emerald' | 'amber' | 'violet' | 'gray'> = {
+    lab: 'emerald', challenge: 'amber', quiz: 'violet', reading: 'gray',
+  }
+  return map[type] ?? 'gray'
 }
 
 function openAddStep() {
@@ -461,7 +464,9 @@ async function moveStep(index: number, dir: -1 | 1) {
   const newIndex = index + dir
   if (newIndex < 0 || newIndex >= steps.value.length) return
   const arr = [...steps.value]
-  ;[arr[index], arr[newIndex]] = [arr[newIndex], arr[index]]
+  // Both indices are bounds-checked above; the non-null assertions narrow
+  // TS's noUncheckedIndexedAccess result back to PathStep.
+  ;[arr[index], arr[newIndex]] = [arr[newIndex]!, arr[index]!]
   steps.value = arr
   try {
     await reorderSteps(pathId.value, arr.map(s => s.id))

--- a/frontend/app/pages/profile.vue
+++ b/frontend/app/pages/profile.vue
@@ -38,7 +38,7 @@
                      hover:bg-emerald-700 dark:border-gray-800"
               title="Change photo"
               :disabled="uploadingAvatar"
-              @click="$refs.avatarInput.click()"
+              @click="avatarInput?.click()"
             >
               <UIcon v-if="uploadingAvatar" name="i-heroicons-arrow-path" class="h-3.5 w-3.5 animate-spin" />
               <UIcon v-else name="i-heroicons-camera" class="h-3.5 w-3.5" />
@@ -88,7 +88,7 @@
                     :href="user.profile[link.key]" target="_blank" rel="noopener"
                     :title="user.profile[link.key]"
                     class="block truncate text-xs text-emerald-700 hover:text-emerald-600 hover:underline dark:text-emerald-400">
-                    {{ user.profile[link.key].replace(/^https?:\/\/(www\.)?/, '') }}
+                    {{ (user.profile[link.key] ?? '').replace(/^https?:\/\/(www\.)?/, '') }}
                   </a>
                   <p v-else class="text-xs italic text-gray-400 dark:text-gray-500">Not set</p>
                 </template>
@@ -239,6 +239,7 @@ const editing          = ref(false)
 const saving           = ref(false)
 const showPasswordForm = ref(false)
 const uploadingAvatar  = ref(false)
+const avatarInput      = ref<HTMLInputElement | null>(null)
 const avatarPreview    = ref<string | null>(null)
 
 const { upload, put } = useApi()
@@ -262,7 +263,7 @@ const socialLinks = [
   { key: 'instagram', label: 'Instagram', icon: 'i-heroicons-camera',       color: '#e1306c' },
   { key: 'facebook',  label: 'Facebook',  icon: 'i-heroicons-user-group',   color: '#1877f2' },
   { key: 'website',   label: 'Website',   icon: 'i-heroicons-globe-alt',    color: '#059669' },
-]
+] as const
 
 function startEdit() {
   form.fullname  = user.value?.fullname  ?? ''
@@ -324,10 +325,14 @@ async function handleAvatarUpload(event: Event) {
 async function saveProfile() {
   saving.value = true
   try {
+    // Backend UserRequest expects `role: roles.id` (numeric). UserResource
+    // only returns the role NAME, so map it back via the RoleEnum ids
+    // (admin=1, client=2, consultant=3). Falls back to client for safety.
+    const roleIds = { admin: 1, client: 2, consultant: 3 } as const
     await put(`/users/${user.value?.id}`, {
       fullname: form.fullname,
       email:    user.value?.email,
-      role:     user.value?.role_id ?? user.value?.roles?.[0]?.id ?? 2,
+      role:     roleIds[user.value?.role ?? 'client'] ?? 2,
       profile: {
         github:    form.github    || null,
         linkedin:  form.linkedin  || null,

--- a/frontend/app/pages/step/[step_id].vue
+++ b/frontend/app/pages/step/[step_id].vue
@@ -168,7 +168,7 @@ const { fetchStep, updateStepProgress } = usePaths()
 
 const stepId = Number(route.params.step_id)
 
-const step = ref<(PathStep & { user_status: string }) | null>(null)
+const step = ref<PathStep | null>(null)
 const pending = ref(true)
 const error = ref(false)
 const saving = ref(false)
@@ -185,11 +185,11 @@ onMounted(async () => {
   }
 })
 
-async function setStatus(status: PathStep['user_status']) {
+async function setStatus(status: NonNullable<PathStep['user_status']>) {
   if (!step.value || saving.value) return
   saving.value = true
   const prev = step.value.user_status
-  step.value = { ...step.value, user_status: status as string }
+  step.value = { ...step.value, user_status: status }
   try {
     await updateStepProgress(stepId, status)
   } catch (err: unknown) {

--- a/frontend/app/pages/users/[id].vue
+++ b/frontend/app/pages/users/[id].vue
@@ -226,7 +226,9 @@ async function handleAssignConsultant() {
     const res = await patch<{ user: any }>(`/users/${userId.value}/consultant`, {
       consultant_id: selectedConsultantId.value,
     })
-    if (selectedUser.value) selectedUser.value = res.user
+    // The composable returns `user` as a readonly ref. Refetch instead of
+    // mutating .value directly so the UI reflects the new consultant.
+    await fetchUser(userId.value)
     selectedConsultantId.value = res.user.consultant_id ?? null
     toast.add({ title: 'Consultant assigned', color: 'green' })
   } catch (e: any) {
@@ -284,7 +286,7 @@ const timelineLabel = (t?: string) => {
   }
 }
 
-const formatDate = (date: string) => new Date(date).toLocaleDateString()
+const formatDate = (date?: string) => (date ? new Date(date).toLocaleDateString() : 'N/A')
 
 onMounted(async () => {
   await fetchUser(userId.value)

--- a/frontend/app/pages/users/create.vue
+++ b/frontend/app/pages/users/create.vue
@@ -118,7 +118,7 @@ const errors = ref<Record<string, string>>({})
 
 interface RoleOption { label: string; value: number }
 const roleOptions = ref<RoleOption[]>([])
-const selectedRole = ref<RoleOption | null>(null)
+const selectedRole = ref<RoleOption | undefined>(undefined)
 
 const form = ref({
   fullname: '',
@@ -177,7 +177,7 @@ const handleSubmit = async () => {
     if (data?.errors) {
       Object.entries(data.errors as Record<string, string[]>).forEach(([field, messages]) => {
         const key = field.replace('profile.', '')
-        errors.value[key] = (messages as string[])[0]
+        errors.value[key] = messages[0] ?? 'Validation error'
       })
       apiError.value = data.message ?? 'Please fix the errors below.'
     } else {

--- a/frontend/app/pages/users/index.vue
+++ b/frontend/app/pages/users/index.vue
@@ -169,7 +169,7 @@ const roleBadgeColor = (role?: string) => {
   }
 }
 
-const formatDate = (date: string) => new Date(date).toLocaleDateString()
+const formatDate = (date?: string) => (date ? new Date(date).toLocaleDateString() : 'N/A')
 
 const goToCreateUser = () => router.push('/users/create')
 const viewUser = (id: number) => router.push(`/users/${id}`)

--- a/frontend/app/types/models.ts
+++ b/frontend/app/types/models.ts
@@ -8,6 +8,7 @@ export interface User {
   email: string
   role?: UserRole
   consultant_id?: number | null
+  consultant?: User | null
   needs_onboarding?: boolean
   profile?: Profile
   created_at?: string
@@ -26,6 +27,13 @@ export interface Profile {
   linkedin?: string
   instagram?: string
   facebook?: string
+  // Onboarding / career fields (added in 2026_04_19 migrations).
+  goal?: string
+  level?: string
+  stack?: string[]
+  product_interest?: string
+  availability_hours?: number
+  timeline?: string
 }
 
 export interface Course {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -18,11 +18,6 @@ export default defineNuxtConfig({
 
   modules: ['@nuxt/ui', '@nuxtjs/seo'],
 
-  ui: {
-    primary: 'emerald',
-    gray: 'slate',
-  },
-
   // @nuxtjs/seo — site-wide config consumed by sitemap, robots,
   // schema.org, and canonical URLs.
   site: {


### PR DESCRIPTION
## Summary
- Make `nuxi typecheck` pass cleanly. The homepage redesign exposed dozens of latent strict-mode TS errors across the frontend; this PR clears them with no intended runtime change.
- Fix a real SSR/hydration bug on the homepage: `mapDots` used `Math.random()` at module evaluation, so the world map shifted on hydrate. Replaced with a seeded PRNG.
- Move `@nuxt/ui` `primary`/`gray` from `nuxt.config.ts` (which fails type check in v2) to `app.config.ts` (the canonical location).
- Extend `Profile` and `User` in `types/models.ts` with the onboarding/career fields the backend already returns (goal, level, stack, product_interest, availability_hours, timeline, consultant); `useUsers` now imports those types instead of redefining a stale local interface.
- `profile.vue`: replace the broken `role_id ?? roles[0].id ?? 2` fallback (UserResource only ships the role name, so the form was silently always sending `role: 2`) with a name→id mapping aligned with `RoleEnum`.
- Various other narrowing fixes: regex match non-null assertions, RoadmapFlow `MarkerType.ArrowClosed`, BadgeColor return-type narrowing in helpers, `formatDate(date?: string)` accepting optional input, drop dead `.hero__photo-stage` / `.float-card*` / `.deco--*` CSS rules left over from the previous home design.

## Test plan
- [x] `ddev artisan test --compact` — 408 passed, 621 assertions
- [x] `npx nuxi typecheck` — exit 0
- [ ] `npm run dev` — load `/`, confirm the world map doesn't jump on hydrate (open Vue devtools console; no hydration mismatch warning)
- [ ] Open `/profile`, edit and save — confirm role is preserved (admin stays admin, consultant stays consultant)
- [ ] Open `/users/<id>` — view a user with full onboarding, confirm Career Profile card renders all fields (level, stack, product, timeline, availability, goal)
- [ ] Open `/users/create` — fill the form, confirm role select still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)