### PR TITLE
feat(paths): seniority layering — Core / Deeper dive / Senior insights

### DIFF
--- a/database/seeders/LearningPathsSeeder.php
+++ b/database/seeders/LearningPathsSeeder.php
@@ -78,7 +78,9 @@ function describe(OrderStatus $status): string {
 echo describe(OrderStatus::Paid);
 EOT,
                         'concept_content' => <<<'EOT'
-## strict_types: opting out of type juggling
+## Core (PHP fundamentals)
+
+### strict_types: opting out of type juggling
 
 Add this single line at the top of every PHP file you write:
 
@@ -101,7 +103,7 @@ tax('150');   // TypeError — strict types blocks the implicit cast
 
 This is the single highest-impact line you can add to a PHP project that didn't have it.
 
-## Parameter, return and property types
+### Parameter, return and property types
 
 PHP supports type declarations on **parameters**, **return values**, and (since 7.4) **class properties**:
 
@@ -122,7 +124,7 @@ class Invoice {
 
 The `void` return type means "this function returns nothing useful". Use it explicitly to make intent unambiguous to both readers and the IDE.
 
-## Nullable shorthand: `?string`
+### Nullable shorthand: ?string
 
 Real data has gaps. A user might not have a `linkedin_url`. The `?` prefix means "this OR null":
 
@@ -135,7 +137,7 @@ function profileUrl(?string $handle): ?string {
 
 `?string` is sugar for `string|null`. Both work; `?` reads cleaner for the common nullable case.
 
-## Union types: when a value can be more than one thing
+### Union types: one of several
 
 PHP 8 added the `|` syntax for parameters that legitimately accept multiple types:
 
@@ -150,9 +152,11 @@ formatId('abc');    // "STR-abc"
 
 Use unions sparingly. If you find yourself writing `int|string|float|bool`, that's a smell — your function is doing too much.
 
-## Intersection types: combining contracts
+## Deeper dive (intermediate territory)
 
-Where unions say "one of these", intersections say "all of these at once". Useful when a parameter must implement multiple interfaces:
+### Intersection types: combining contracts
+
+Where unions say "one of these", intersections say "all of these at once". Useful when a parameter must implement multiple interfaces simultaneously:
 
 ```php
 function dumpSize(Countable&Stringable $value): string {
@@ -160,9 +164,9 @@ function dumpSize(Countable&Stringable $value): string {
 }
 ```
 
-The parameter must implement **both** `Countable` and `Stringable`. The compiler enforces it; you don't have to check at runtime.
+The parameter must implement **both** `Countable` and `Stringable`. The compiler enforces it; no runtime checks needed. Intersections compose well with the standard SPL interfaces (`Iterator`, `Countable`, `Stringable`, `JsonSerializable`) and your own contracts.
 
-## Enums: the death of magic strings
+### Enums: the death of magic strings
 
 Before PHP 8.1, status fields were stored as untyped strings or class constants. Both invited typos:
 
@@ -197,13 +201,69 @@ Three real wins:
 - **Exhaustive `match`** — add a new case and the compiler points at every `match` that doesn't handle it.
 - **Methods on the enum** — `isFinal()` lives next to the data, not scattered across helpers.
 
-Backed enums (`: string` or `: int`) serialise to the database and back via `OrderStatus::from('paid')`. Use string-backed for human-readable storage, int-backed for compact indexed columns.
+### Backed enums for persistence
 
-## Why this matters at work
+Backed enums (`: string` or `: int`) serialise to the database and back. Use `OrderStatus::from('paid')` to hydrate, `OrderStatus::tryFrom($value)` when the input might be invalid:
 
-Code reviews stop arguing about defensive `is_string()` checks. IDEs autocomplete enum cases. New team members read a signature and understand the contract without reading the function body. Migrations from PHP 7 codebases recover dozens of latent bugs the moment strict types go on.
+```php
+$status = OrderStatus::tryFrom($row['status']) ?? OrderStatus::Pending;
+```
 
-If your team is still arguing about whether typed properties are worth it, point them at the next time prod 500s because someone passed `"true"` (the string) to a function expecting `bool`.
+String-backed for human-readable storage. Int-backed when you need compact indexed columns (e.g. a high-write events table). Laravel's `Eloquent` casts (`'status' => OrderStatus::class`) make the model property a real enum without lifting a finger.
+
+### Property covariance and variance gotchas
+
+PHP allows return-type **covariance** (a child can narrow the return) but parameter types are **invariant** in most cases. This bites when refactoring inheritance:
+
+```php
+class Repository {
+    public function find(int $id): ?Model { /* ... */ }
+}
+
+class UserRepository extends Repository {
+    public function find(int $id): ?User { /* OK — covariant return */ }
+}
+```
+
+But you cannot widen a parameter in a child — that breaks LSP and PHP rightly refuses. When you hit one of these errors, the fix is almost always to redesign the contract rather than fight the type system.
+
+## Senior insights (architecture & interview prep)
+
+### Code-review red flags
+
+Things to call out the next time you review a teammate's PR:
+
+- **`mixed` everywhere.** A function returning `mixed` is a function that gave up on types. Push for a union or a value-object wrapper.
+- **`@param string $foo` PHPDoc instead of a real type.** PHPDoc is hints; only the declaration is enforced. If the parameter can be typed, type it.
+- **`stdClass` instead of a DTO.** "We'll just decode JSON to stdClass for now" is how every PHP codebase ends up with untyped property access bugs in production. Decode into a typed class.
+- **`null` returned from a method whose name promises a value.** `getUser(): ?User` is sometimes right, but `currentUser(): ?User` smells — call sites end up with `if ($user === null)` everywhere. A `requireUser(): User` that throws is often the right contract.
+- **A method that accepts `string|int|array`.** That's a function doing three jobs. Split it.
+
+### When to adopt strict_types in a legacy codebase
+
+Strict types is per-file. You don't have to migrate everything at once — that's a feature, not a workaround. A pragmatic rollout:
+
+1. **Add it to new files only.** Set a lint rule (`php-cs-fixer` `declare_strict_types`) so every new PHP file ships with `declare(strict_types=1)` at the top.
+2. **Migrate file-by-file when you touch a file for another reason.** Boy-scout rule: leave it cleaner than you found it. Don't open dedicated "add strict types to module X" PRs — they're large, mechanical, and high-blast-radius.
+3. **Run the test suite after each batch.** Strict types surfaces real bugs (typically: `$_GET`/`$_POST` strings being passed unchanged to int-typed functions). The test suite is your safety net.
+
+If a function genuinely needs to accept loose input (e.g. an HTTP request handler before validation), normalise at the boundary — don't disable strict types for the entire file.
+
+### Trade-offs to discuss with your team
+
+- **Enums vs. database-friendly constants.** Enums break older Laravel ecosystems that didn't expect them; some packages serialise them inconsistently. Keep an `->value` accessor handy.
+- **Union types vs. polymorphism.** A union of two types in one function is often a missed opportunity for two methods or a small interface. Use unions when the two types have legitimately the same processing path.
+- **Performance.** Type declarations cost nothing at runtime — opcache caches the parsed AST. Don't let anyone tell you otherwise.
+
+### What interviewers listen for
+
+Common technical-screen prompts and the bullet they're waiting for:
+
+- *"How do PHP comparisons work?"* — Mention strict (`===`) vs loose (`==`), then go straight to the security angle: type-juggling in `==` is exploitable when comparing user input against tokens or roles.
+- *"What's the difference between an abstract class and an interface?"* — Senior answer: interfaces describe a contract; abstract classes share *implementation*. PHP 8 added interface intersection types — interfaces have grown more expressive, abstract classes less necessary.
+- *"How would you refactor a function that returns `mixed`?"* — Start by enumerating the actual return shapes the function produces. Replace with a union, a value object, or a sealed hierarchy of result types. Show that you reach for types as a *design* tool, not a syntax tax.
+
+The senior bar isn't memorising every union/intersection rule. It's reaching for the type system as a way to make wrong code unrepresentable.
 EOT,
                         'resources' => [
                             ['label' => 'PHP 8.3 Type System', 'url' => 'https://www.php.net/manual/en/language.types.declarations.php'],

--- a/frontend/app/components/StepConceptView.vue
+++ b/frontend/app/components/StepConceptView.vue
@@ -63,24 +63,32 @@
             </div>
           </UCard>
 
-          <!-- TOC -->
+          <!-- TOC (tier → subsections) -->
           <UCard v-if="toc.length" :ui="{ body: { padding: 'p-4' } }">
             <p class="mb-3 text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
               On this step
             </p>
             <nav class="space-y-1">
-              <a
-                v-for="t in toc"
-                :key="t.id"
-                :href="`#${t.id}`"
-                class="block rounded-md px-2 py-1 text-xs transition-colors"
-                :class="activeTocId === t.id
-                  ? 'bg-emerald-50 font-semibold text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300'
-                  : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-slate-800/60 dark:hover:text-gray-200'"
-                @click.prevent="scrollTo(t.id)"
-              >
-                {{ t.text }}
-              </a>
+              <template v-for="t in toc" :key="t.id">
+                <a
+                  v-show="isTierVisible(t.tier)"
+                  :href="`#${t.id}`"
+                  class="block rounded-md px-2 py-1 transition-colors"
+                  :class="[
+                    t.level === 2
+                      ? 'text-[11px] font-bold uppercase tracking-widest text-gray-700 dark:text-gray-300'
+                      : 'pl-4 text-xs',
+                    activeTocId === t.id
+                      ? 'bg-emerald-50 font-semibold text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300'
+                      : t.level === 2
+                        ? 'mt-2 hover:text-gray-900 dark:hover:text-gray-100'
+                        : 'text-gray-500 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-slate-800/60 dark:hover:text-gray-200',
+                  ]"
+                  @click.prevent="scrollTo(t.id)"
+                >
+                  {{ t.text }}
+                </a>
+              </template>
             </nav>
           </UCard>
 
@@ -154,9 +162,49 @@
 
         <!-- Concept content -->
         <UCard v-if="step.concept_content">
+          <!-- Seniority filter pill bar (only renders if step has tiered content) -->
+          <template v-if="hasTiers" #header>
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <h2 class="flex items-center gap-2 text-base font-semibold text-gray-900 dark:text-white">
+                <UIcon name="i-heroicons-book-open" class="h-5 w-5 text-emerald-500" />
+                Concept
+              </h2>
+              <div class="flex items-center gap-1.5">
+                <span class="mr-1 text-[10px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+                  Showing for
+                </span>
+                <button
+                  v-for="opt in tierFilterOptions"
+                  :key="opt.value"
+                  class="rounded-full border px-2.5 py-1 text-[11px] font-semibold transition-colors"
+                  :class="activeFilter === opt.value
+                    ? 'border-emerald-500 bg-emerald-500 text-white'
+                    : 'border-gray-200 text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-gray-200'"
+                  @click="activeFilter = opt.value"
+                >
+                  {{ opt.label }}
+                </button>
+              </div>
+            </div>
+          </template>
+
           <article ref="contentRef" class="step-concept">
+            <!-- Tiered render: one <section> per tier so we can hide them via CSS. -->
+            <template v-if="hasTiers">
+              <section
+                v-for="(t, i) in tierSections"
+                :key="i"
+                v-show="isTierVisible(t.tier)"
+                :data-tier="t.tier"
+                class="step-concept__tier"
+              >
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <div v-html="t.html" />
+              </section>
+            </template>
+            <!-- Untiered fallback (legacy steps without tier markers). -->
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <div v-html="renderedConcept" />
+            <div v-else v-html="renderedConcept" />
           </article>
         </UCard>
 
@@ -435,12 +483,111 @@ function renderMarkdown(md: string): string {
     .replace(/(^|\n)([^<\n][^\n]+)(?=\n|$)/g, (_, prefix: string, line: string) => `${prefix}<p>${line}</p>`)
 }
 
+// ─── Seniority tier parsing ───────────────────────────────────────────
+// Convention: a step's concept_content is structured as up to three
+// top-level H2 sections whose heading text begins with "Core",
+// "Deeper dive" or "Senior". Steps that don't follow the convention
+// render untouched via the fallback below.
+type Tier = 'core' | 'mid' | 'senior'
+
+function classifyHeading(text: string): Tier {
+  const lower = text.toLowerCase().trim()
+  if (lower.startsWith('deeper dive')) return 'mid'
+  if (lower.startsWith('senior')) return 'senior'
+  return 'core'
+}
+
+interface TocEntry {
+  id: string
+  text: string
+  level: 2 | 3
+  tier: Tier
+}
+
+interface TierSection {
+  tier: Tier
+  markdown: string
+  html: string
+  headings: TocEntry[]
+}
+
+const tierSections = computed<TierSection[]>(() => {
+  const md = props.step.concept_content ?? ''
+  // Split right BEFORE every "## " (lookahead). Drop the leading chunk if
+  // it doesn't start with a tier H2 — that's intro prose, prepended to
+  // the first real tier so we don't lose it.
+  const chunks = md.split(/(?=^## )/m).filter(c => c.trim())
+  if (!chunks.length) return []
+
+  const sections: TierSection[] = []
+  let prelude = ''
+  if (!chunks[0]!.startsWith('## ')) {
+    prelude = chunks.shift()!
+  }
+
+  for (const chunk of chunks) {
+    const lines = chunk.split('\n')
+    const h2Line = lines[0]!.match(/^## (.+)$/)
+    if (!h2Line) continue
+    const h2Text = h2Line[1]!
+    const tier = classifyHeading(h2Text)
+
+    const headings: TocEntry[] = [{ id: slug(h2Text), text: h2Text, level: 2, tier }]
+    for (const line of lines.slice(1)) {
+      const h3 = line.match(/^### (.+)$/)
+      if (h3) headings.push({ id: slug(h3[1]!), text: h3[1]!, level: 3, tier })
+    }
+
+    // The first section absorbs any prelude so untiered intro prose
+    // stays visible.
+    const markdown = prelude && sections.length === 0 ? prelude + chunk : chunk
+    sections.push({ tier, markdown, html: renderMarkdown(markdown), headings })
+  }
+
+  return sections
+})
+
+const hasTiers = computed(() => {
+  // Only treat content as tiered if at least one section is non-core OR
+  // an explicit "Core" header is present. Otherwise fall back to flat
+  // rendering for legacy steps.
+  const tiers = new Set(tierSections.value.map(s => s.tier))
+  if (tiers.size > 1) return true
+  const firstH2 = (props.step.concept_content ?? '').match(/^## (.+)$/m)
+  return firstH2 ? /^(core|deeper dive|senior)/i.test(firstH2[1]!) : false
+})
+
+// Untiered fallback render.
 const renderedConcept = computed(() => renderMarkdown(props.step.concept_content ?? ''))
 
-const toc = computed(() => {
+const toc = computed<TocEntry[]>(() => {
+  if (hasTiers.value) {
+    return tierSections.value.flatMap(s => s.headings)
+  }
+  // Untiered: only show H2 entries as before.
   const matches = [...(props.step.concept_content ?? '').matchAll(/^## (.+)$/gm)]
-  return matches.map(m => ({ id: slug(m[1]!), text: m[1]! }))
+  return matches.map(m => ({ id: slug(m[1]!), text: m[1]!, level: 2 as const, tier: 'core' as const }))
 })
+
+// ─── Filter pill bar ──────────────────────────────────────────────────
+type Filter = 'all' | 'junior' | 'mid' | 'senior'
+const activeFilter = ref<Filter>('all')
+const tierFilterOptions: Array<{ value: Filter; label: string }> = [
+  { value: 'all',    label: 'All' },
+  { value: 'junior', label: 'Junior' },
+  { value: 'mid',    label: 'Mid' },
+  { value: 'senior', label: 'Senior' },
+]
+
+// Map filter intent → which tiers are visible. Each filter focuses on a
+// single tier; "All" shows everything.
+function isTierVisible(tier: Tier): boolean {
+  if (activeFilter.value === 'all') return true
+  if (activeFilter.value === 'junior') return tier === 'core'
+  if (activeFilter.value === 'mid')    return tier === 'mid'
+  if (activeFilter.value === 'senior') return tier === 'senior'
+  return true
+}
 
 // ─── Scroll-spy ────────────────────────────────────────────────────────
 const contentRef = ref<HTMLElement | null>(null)
@@ -466,7 +613,7 @@ onMounted(() => {
 
   nextTick(() => {
     if (!contentRef.value) return
-    contentRef.value.querySelectorAll('h2[id]').forEach(h => observer.observe(h))
+    contentRef.value.querySelectorAll('h2[id], h3[id]').forEach(h => observer.observe(h))
   })
 
   onUnmounted(() => observer.disconnect())
@@ -510,6 +657,58 @@ async function runPlayground() {
 }
 :global(.dark) .step-concept :deep(h2) { color: rgb(243 244 246); }
 .step-concept :deep(h2:first-child) { margin-top: 0; }
+
+/* ── Tier sections ─────────────────────────────────────────────── */
+/* Each tier is rendered inside its own <section data-tier="...">.
+   The section's own H2 (the tier name) gets a stronger visual treatment
+   with a colored eyebrow tag so the reader feels the level change. */
+.step-concept__tier {
+  position: relative;
+  padding-top: 8px;
+}
+.step-concept__tier + .step-concept__tier {
+  margin-top: 48px;
+  padding-top: 32px;
+  border-top: 1px dashed rgb(226 232 240);
+}
+:global(.dark) .step-concept__tier + .step-concept__tier {
+  border-color: rgb(51 65 85);
+}
+
+.step-concept__tier :deep(h2) {
+  position: relative;
+  margin-top: 12px;
+  margin-bottom: 18px;
+  font-size: 1.5rem;
+  letter-spacing: -0.02em;
+}
+.step-concept__tier :deep(h2)::before {
+  content: attr(data-tier-label);
+  display: block;
+  margin-bottom: 8px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.step-concept__tier[data-tier="core"] :deep(h2)::before {
+  content: 'Core — foundations';
+  color: rgb(5 150 105);
+}
+.step-concept__tier[data-tier="mid"] :deep(h2)::before {
+  content: 'Deeper dive — for mid-level engineers';
+  color: rgb(217 119 6);
+}
+.step-concept__tier[data-tier="senior"] :deep(h2)::before {
+  content: 'Senior insights — interview & architecture';
+  color: rgb(124 58 237);
+}
+.step-concept__tier[data-tier="core"]   :deep(h2) { color: rgb(6 95 70); }
+.step-concept__tier[data-tier="mid"]    :deep(h2) { color: rgb(146 64 14); }
+.step-concept__tier[data-tier="senior"] :deep(h2) { color: rgb(91 33 182); }
+:global(.dark) .step-concept__tier[data-tier="core"]   :deep(h2) { color: rgb(110 231 183); }
+:global(.dark) .step-concept__tier[data-tier="mid"]    :deep(h2) { color: rgb(252 211 77); }
+:global(.dark) .step-concept__tier[data-tier="senior"] :deep(h2) { color: rgb(196 181 253); }
 
 .step-concept :deep(h3) {
   scroll-margin-top: 80px;


### PR DESCRIPTION
## Summary
- Each rich step's `concept_content` can now be authored as three top-level H2 sections — "Core", "Deeper dive", "Senior insights" — that the viewer can filter via a pill bar in the concept card header.
- Convention is markdown-only; no schema change.
- The pilot step ("Modern PHP: Types, Nullables and Enums") is rewritten in the new format and gets a whole new Senior-tier section with code-review red flags, strict_types adoption strategy, variance gotchas, and interview-prep talking points.

## How it works
- A step's `concept_content` is split right before every `## ` heading. The H2 text classifies the section: `core` (default), `mid` (`Deeper dive…`), or `senior` (`Senior…`).
- Each tier renders inside its own `<section data-tier="…">`. The filter pill bar (`All` / `Junior` / `Mid` / `Senior`) flips visibility with v-show — no re-render, scroll position preserved.
- Tier-level H2s get a coloured eyebrow tag and tier-specific heading colour. Subtopic H3s render as before.
- The TOC becomes two-level: tier label grouping its subtopics. Entries belonging to hidden tiers are hidden too.

## Legacy steps unaffected
The pill bar only appears when the content actually has tier markers. The 36 other seeded steps continue to render in the previous flat layout — they'll opt in as their content gets rewritten.

## Test plan
- [x] `ddev artisan migrate:fresh --seed` — re-seeds cleanly; \`PathStep::find(1)->concept_content\` contains all three tier markers (\`## Core\`, \`## Deeper dive\`, \`## Senior insights\`) and is ~8.5kb.
- [x] `ddev artisan test --compact` — 408 passed, 621 assertions.
- [x] `npx nuxi typecheck` — exit 0.
- [ ] `cd frontend && npm run dev`, sign in, visit `/step/1`. Confirm:
  - Pill bar appears in the Concept card header.
  - `All` shows all three tiers with coloured headings (emerald / amber / violet).
  - `Junior` hides Deeper dive + Senior, only Core stays.
  - `Mid` hides Core + Senior, only Deeper dive stays.
  - `Senior` hides Core + Deeper dive, only Senior insights stays.
  - TOC entries hide/show alongside their tier.
- [ ] Visit a legacy step (`/step/2` "Laravel Request Lifecycle…"). Confirm the pill bar does **not** appear (no tier markers), and the page renders the same as before.

## Follow-ups still queued
- Playground execution wiring (Judge0 endpoint).
- Per-user checklist persistence.
- Migrate the remaining 6 steps in "PHP for the Real World" to tiered content.
- Other tracks (Observability path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)