### PR TITLE
feat(paths): practice tasks → editable playground with real Judge0 execution

### DIFF
--- a/app/Http/Controllers/Api/PathStepController.php
+++ b/app/Http/Controllers/Api/PathStepController.php
@@ -110,6 +110,7 @@ class PathStepController extends Controller
             'instructions' => 'nullable|array',
             'instructions.*.id' => 'required|integer',
             'instructions.*.text' => 'required|string|max:2000',
+            'instructions.*.starter_code' => 'nullable|string|max:10000',
             'challenge_prompt' => 'nullable|string',
             'challenge_slug' => 'nullable|string|exists:challenges,slug',
         ];

--- a/app/Http/Controllers/Api/PlaygroundController.php
+++ b/app/Http/Controllers/Api/PlaygroundController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\PlaygroundExecutionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PlaygroundController extends Controller
+{
+    public function run(Request $request, PlaygroundExecutionService $executor): JsonResponse
+    {
+        $validated = $request->validate([
+            'code' => ['required', 'string', 'max:10000'],
+            'language' => ['nullable', 'string', 'in:php'],
+        ]);
+
+        $result = $executor->run($validated['code']);
+
+        return response()->json($result);
+    }
+}

--- a/app/Services/PlaygroundExecutionService.php
+++ b/app/Services/PlaygroundExecutionService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Runs arbitrary PHP code in a Judge0 sandbox and returns whatever the
+ * script printed. Unlike {@see ChallengeExecutionService} there is no
+ * test framework wrapper — the input code is executed verbatim, which
+ * makes this suitable for the step-page playground where the user just
+ * wants to experiment.
+ */
+class PlaygroundExecutionService
+{
+    private const DEFAULT_LANGUAGE_ID = 68; // PHP 7.4 on Judge0 CE; override via config
+
+    private const CPU_TIME_LIMIT = 5;
+
+    private const MEMORY_LIMIT_KB = 131072; // 128 MB
+
+    private string $baseUrl;
+
+    private string $authToken;
+
+    private int $languageId;
+
+    public function __construct()
+    {
+        $this->baseUrl = rtrim((string) config('services.judge0.url', 'https://judge0-ce.p.rapidapi.com'), '/');
+        $this->authToken = (string) config('services.judge0.token', '');
+        $this->languageId = (int) config('services.judge0.language_id', self::DEFAULT_LANGUAGE_ID);
+    }
+
+    /**
+     * @return array{
+     *     ok: bool,
+     *     stdout: string,
+     *     stderr: string,
+     *     exit_code: int,
+     *     duration_ms: int,
+     *     status: string,
+     * }
+     */
+    public function run(string $code): array
+    {
+        $response = Http::withHeaders($this->buildHeaders())
+            ->timeout(30)
+            ->post("{$this->baseUrl}/submissions?base64_encoded=true&wait=true", [
+                'source_code' => base64_encode($code),
+                'language_id' => $this->languageId,
+                'stdin' => '',
+                'cpu_time_limit' => self::CPU_TIME_LIMIT,
+                'memory_limit' => self::MEMORY_LIMIT_KB,
+            ]);
+
+        if ($response->failed()) {
+            Log::error('Judge0 playground request failed', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
+            return [
+                'ok' => false,
+                'stdout' => '',
+                'stderr' => "Sandbox request failed ({$response->status()}).",
+                'exit_code' => -1,
+                'duration_ms' => 0,
+                'status' => 'request_failed',
+            ];
+        }
+
+        $data = (array) $response->json();
+        $stdout = isset($data['stdout']) ? (string) base64_decode($data['stdout']) : '';
+        $stderr = isset($data['stderr']) ? (string) base64_decode($data['stderr']) : '';
+        $compileOutput = isset($data['compile_output']) ? (string) base64_decode($data['compile_output']) : '';
+        $exitCode = (int) ($data['exit_code'] ?? 0);
+        $durationMs = (int) ((float) ($data['time'] ?? 0) * 1000);
+        $statusId = (int) ($data['status']['id'] ?? 0);
+
+        return match (true) {
+            $statusId === 6 => [
+                'ok' => false,
+                'stdout' => '',
+                'stderr' => $compileOutput ?: $stderr ?: 'Compilation error.',
+                'exit_code' => $exitCode,
+                'duration_ms' => $durationMs,
+                'status' => 'compile_error',
+            ],
+            $statusId === 5 => [
+                'ok' => false,
+                'stdout' => $stdout,
+                'stderr' => 'Time limit exceeded ('.self::CPU_TIME_LIMIT.'s).',
+                'exit_code' => $exitCode,
+                'duration_ms' => $durationMs,
+                'status' => 'timeout',
+            ],
+            default => [
+                'ok' => $exitCode === 0,
+                'stdout' => $stdout,
+                'stderr' => $stderr,
+                'exit_code' => $exitCode,
+                'duration_ms' => $durationMs,
+                'status' => $exitCode === 0 ? 'ok' : 'runtime_error',
+            ],
+        };
+    }
+
+    private function buildHeaders(): array
+    {
+        $host = (string) parse_url($this->baseUrl, PHP_URL_HOST);
+
+        if (str_contains($host, 'rapidapi')) {
+            return [
+                'Content-Type' => 'application/json',
+                'X-RapidAPI-Key' => $this->authToken,
+                'X-RapidAPI-Host' => $host,
+            ];
+        }
+
+        return [
+            'Content-Type' => 'application/json',
+            'X-Auth-Token' => $this->authToken,
+        ];
+    }
+}

--- a/database/seeders/LearningPathsSeeder.php
+++ b/database/seeders/LearningPathsSeeder.php
@@ -271,11 +271,136 @@ EOT,
                             ['label' => 'Typed Properties RFC', 'url' => 'https://wiki.php.net/rfc/typed_properties_v2'],
                         ],
                         'instructions' => [
-                            ['id' => 1, 'text' => "Form payload sanitizer — write sanitizeSignup(array \$raw): array that takes \$_POST-style input and returns typed fields: email (trimmed string), age (int, 0 if missing), terms_accepted (bool from 'yes'/'1'/'true'), referral_code (?string). This is what every onboarding controller does on day one."],
-                            ['id' => 2, 'text' => "Strict types refactor — a teammate wrote function calculateDiscount(\$price, \$percent) { return \$price - (\$price * \$percent / 100); }. Add declare(strict_types=1), parameter types, and a return type. Then call it with ('10.50', 10) and explain what changes between strict and non-strict mode."],
-                            ['id' => 3, 'text' => "Security: type juggling bypass — explain why if (\$_GET['role'] == 'admin') is exploitable when a request is crafted as ?role=0 in PHP 7. Fix it with strict equality and a whitelist. Classic technical-screen question for senior backend roles."],
-                            ['id' => 4, 'text' => "Convert magic strings to an enum — find any model in your project that has a status column stored as a raw string. Define a backed enum, cast the property, and update one match() that checks the status to be exhaustive."],
-                            ['id' => 5, 'text' => "Money math — a junior writes \$total = 0.1 + 0.2 and asserts === 0.3. Explain why the assertion fails. Then implement sumCents(array \$stringPrices): int that takes ['9.99', '1.50', '0.01'] and returns the total in cents (integer) — the only safe way to handle money in any language."],
+                            [
+                                'id' => 1,
+                                'text' => "Form payload sanitizer — write sanitizeSignup(array \$raw): array that takes \$_POST-style input and returns typed fields: email (trimmed string), age (int, 0 if missing), terms_accepted (bool from 'yes'/'1'/'true'), referral_code (?string). This is what every onboarding controller does on day one.",
+                                'starter_code' => <<<'PHP'
+<?php
+declare(strict_types=1);
+
+/**
+ * Sanitize a raw $_POST-style array into typed fields.
+ *   - email          → trimmed string
+ *   - age            → int (0 if missing)
+ *   - terms_accepted → bool, true when value is 'yes' / '1' / 'true' (case-insensitive)
+ *   - referral_code  → string or null
+ */
+function sanitizeSignup(array $raw): array
+{
+    // TODO: implement
+    return [];
+}
+
+// Try your implementation against these:
+var_dump(sanitizeSignup([
+    'email' => '  alice@example.com  ',
+    'age' => '25',
+    'terms_accepted' => 'yes',
+    'referral_code' => 'WELCOME10',
+]));
+var_dump(sanitizeSignup([]));
+var_dump(sanitizeSignup(['terms_accepted' => 'no']));
+PHP,
+                            ],
+                            [
+                                'id' => 2,
+                                'text' => "Strict types refactor — a teammate wrote function calculateDiscount(\$price, \$percent) { return \$price - (\$price * \$percent / 100); }. Add declare(strict_types=1), parameter types, and a return type. Then call it with ('10.50', 10) and explain what changes between strict and non-strict mode.",
+                                'starter_code' => <<<'PHP'
+<?php
+// Step 1: add declare(strict_types=1); on the line above this comment.
+
+// Step 2: add parameter types and a return type to this function.
+function calculateDiscount($price, $percent)
+{
+    return $price - ($price * $percent / 100);
+}
+
+// Step 3: run BOTH calls and see what changes between strict and non-strict mode.
+echo calculateDiscount(10.50, 10) . PHP_EOL;     // 9.45
+echo calculateDiscount('10.50', 10) . PHP_EOL;   // ← with strict_types this throws TypeError
+PHP,
+                            ],
+                            [
+                                'id' => 3,
+                                'text' => "Security: type juggling bypass — explain why if (\$_GET['role'] == 'admin') is exploitable when a request is crafted as ?role=0 in PHP 7. Fix it with strict equality and a whitelist. Classic technical-screen question for senior backend roles.",
+                                'starter_code' => <<<'PHP'
+<?php
+// The vulnerable controller below is in production. Two things to do:
+//
+//  1. In a comment, explain WHY this returns true when an attacker sends
+//     ?role=0 under PHP 7 semantics. (Hint: 'admin' == 0)
+//
+//  2. Rewrite isAdmin() using strict equality and a whitelist of allowed
+//     roles. Make it impossible to bypass with crafted input.
+
+function isAdmin(array $request): bool
+{
+    return $request['role'] == 'admin'; // ← exploitable
+}
+
+// Crafted requests — your fixed version must return false for both.
+var_dump(isAdmin(['role' => 0]));        // current code: true (BUG)
+var_dump(isAdmin(['role' => 'admin']));  // legitimate admin: true
+var_dump(isAdmin(['role' => 'user']));   // regular user: false
+PHP,
+                            ],
+                            [
+                                'id' => 4,
+                                'text' => "Convert magic strings to an enum — find any model in your project that has a status column stored as a raw string. Define a backed enum, cast the property, and update one match() that checks the status to be exhaustive.",
+                                'starter_code' => <<<'PHP'
+<?php
+declare(strict_types=1);
+
+// Define a string-backed enum OrderStatus with three cases:
+//   Pending = 'pending', Paid = 'paid', Refunded = 'refunded'
+//
+// Then add a method isFinal(): bool that uses an exhaustive match()
+// — Paid and Refunded are final, Pending is not.
+
+enum OrderStatus: string
+{
+    // TODO: cases
+}
+
+// Once defined, this should compile and run.
+function describe(OrderStatus $status): string
+{
+    return match ($status) {
+        // TODO: cover every case exhaustively — drop any case here and
+        // your IDE/PHPStan should immediately flag it as unhandled.
+    };
+}
+
+// echo describe(OrderStatus::Paid);
+// var_dump(OrderStatus::Pending->isFinal());   // false
+// var_dump(OrderStatus::Refunded->isFinal());  // true
+PHP,
+                            ],
+                            [
+                                'id' => 5,
+                                'text' => "Money math — a junior writes \$total = 0.1 + 0.2 and asserts === 0.3. Explain why the assertion fails. Then implement sumCents(array \$stringPrices): int that takes ['9.99', '1.50', '0.01'] and returns the total in cents (integer) — the only safe way to handle money in any language.",
+                                'starter_code' => <<<'PHP'
+<?php
+declare(strict_types=1);
+
+// Part 1 — convince yourself the float assertion fails.
+var_dump(0.1 + 0.2);                  // 0.30000000000000004
+var_dump(0.1 + 0.2 === 0.3);          // false  ← IEEE 754 talking
+
+// Part 2 — implement sumCents.
+// Take prices as strings (the way HTTP forms and CSV files give them),
+// convert each to integer cents (e.g. '9.99' → 999), and sum.
+function sumCents(array $stringPrices): int
+{
+    // TODO: implement — avoid floats entirely if you can.
+    return 0;
+}
+
+echo sumCents(['9.99', '1.50', '0.01']) . PHP_EOL;   // expected: 1150
+echo sumCents(['100.00', '0.99']) . PHP_EOL;         // expected: 10099
+echo sumCents([]) . PHP_EOL;                          // expected: 0
+PHP,
+                            ],
                         ],
                         'challenge_prompt' => null,
                         'lab_url' => null,

--- a/frontend/app/components/StepConceptView.vue
+++ b/frontend/app/components/StepConceptView.vue
@@ -253,19 +253,33 @@
           </div>
 
           <div class="playground-editor">
-            <pre><code><span
-              v-for="(line, idx) in playgroundLines"
-              :key="idx"
-              class="playground-line"
-            ><span class="playground-line__num">{{ idx + 1 }}</span><!-- eslint-disable-next-line vue/no-v-html
-            --><span class="playground-line__src" v-html="line || '&nbsp;'" /></span></code></pre>
+            <ClientOnly>
+              <VueMonacoEditor
+                v-model:value="playgroundCode"
+                language="php"
+                theme="vs-dark"
+                :options="monacoOptions"
+                class="h-full"
+              />
+              <template #fallback>
+                <div class="flex items-center justify-center px-6 py-10 text-xs text-slate-500">
+                  Loading editor…
+                </div>
+              </template>
+            </ClientOnly>
           </div>
 
           <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 dark:border-slate-800 dark:bg-slate-900">
-            <p class="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
-              Output
-            </p>
-            <pre v-if="playgroundOutput" class="playground-output">{{ playgroundOutput }}</pre>
+            <div class="mb-1.5 flex items-center justify-between gap-3">
+              <p class="text-[10px] font-semibold uppercase tracking-widest text-gray-500 dark:text-gray-400">
+                Output
+              </p>
+              <p v-if="playgroundDurationMs !== null" class="text-[10px] text-gray-400 dark:text-gray-600">
+                {{ playgroundDurationMs }} ms
+              </p>
+            </div>
+            <pre v-if="playgroundError" class="playground-output playground-output--err">{{ playgroundError }}</pre>
+            <pre v-else-if="playgroundOutput" class="playground-output">{{ playgroundOutput }}</pre>
             <p v-else class="font-mono text-xs italic text-gray-400 dark:text-gray-600">
               Press Run to see the output here.
             </p>
@@ -372,6 +386,7 @@
 </template>
 
 <script setup lang="ts">
+import { VueMonacoEditor } from '@guolao/vue-monaco-editor'
 import type { PathStep, StepDifficulty } from '~/composables/usePaths'
 
 const props = defineProps<{
@@ -636,33 +651,85 @@ onMounted(() => {
   onUnmounted(() => observer.disconnect())
 })
 
-// ─── Playground (mocked; execution will land in a follow-up PR) ───────
+// ─── Playground (Monaco-backed editor, Judge0-backed Run) ─────────────
 const playgroundCode = ref(props.step.playground_starter_code ?? '')
 const playgroundOutput = ref('')
+const playgroundError = ref('')
 const playgroundRunning = ref(false)
+const playgroundDurationMs = ref<number | null>(null)
 const playgroundCard = ref<{ $el?: HTMLElement } | null>(null)
 const activeTaskId = ref<number | null>(null)
-const playgroundLines = computed(() => playgroundCode.value.split('\n').map(highlightPhp))
 const toast = useToast()
+const api = useApi()
+
+const monacoOptions = {
+  fontSize: 13,
+  fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
+  fontLigatures: true,
+  lineHeight: 20,
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  padding: { top: 16, bottom: 16 },
+  tabSize: 4,
+  wordWrap: 'on' as const,
+  renderLineHighlight: 'gutter' as const,
+  overviewRulerBorder: false,
+  hideCursorInOverviewRuler: true,
+}
+
+interface PlaygroundResult {
+  ok: boolean
+  stdout: string
+  stderr: string
+  exit_code: number
+  duration_ms: number
+  status: string
+}
 
 function resetPlayground() {
   playgroundCode.value = props.step.playground_starter_code ?? ''
   playgroundOutput.value = ''
+  playgroundError.value = ''
+  playgroundDurationMs.value = null
   activeTaskId.value = null
 }
 
 async function runPlayground() {
+  if (playgroundRunning.value) return
   playgroundRunning.value = true
   playgroundOutput.value = ''
-  // TODO: replace with a real call to a playground endpoint (Judge0 backed)
-  // that executes arbitrary PHP without comparing against tests_code.
-  await new Promise(r => setTimeout(r, 500))
-  playgroundRunning.value = false
-  toast.add({
-    title: 'Playground execution coming soon',
-    description: 'Wire-up to Judge0 lands in a follow-up PR.',
-    color: 'amber',
-  })
+  playgroundError.value = ''
+  playgroundDurationMs.value = null
+  try {
+    const result = await api.post<PlaygroundResult>('/playground/run', {
+      code: playgroundCode.value,
+      language: 'php',
+    })
+    playgroundDurationMs.value = result.duration_ms
+    // Compile errors and timeouts already arrive as stderr in our shape.
+    if (result.stderr && !result.ok) {
+      playgroundError.value = result.stderr
+    } else {
+      playgroundOutput.value = result.stdout || '(no output)'
+      // Surface stderr separately if both stdout and stderr came through.
+      if (result.stderr) {
+        playgroundError.value = result.stderr
+      }
+    }
+  } catch (err: unknown) {
+    const data = (err as { data?: { message?: string }, status?: number })
+    if (data?.status === 429) {
+      toast.add({
+        title: 'Slow down',
+        description: 'Too many runs in a short window. Try again in a minute.',
+        color: 'amber',
+      })
+    } else {
+      playgroundError.value = data?.data?.message ?? 'Sandbox request failed. Please try again.'
+    }
+  } finally {
+    playgroundRunning.value = false
+  }
 }
 
 // Load a task's starter into the playground and scroll the editor into
@@ -879,39 +946,16 @@ function loadTaskIntoPlayground(starter: string | null | undefined) {
 :global(.dark) .step-concept :deep(.t-op) { color: #d4d4d4; }
 :global(.dark) .step-concept :deep(.t-tg) { color: #569cd6; font-weight: 600; }
 
-/* Code playground (read-only mock — Monaco lands in a follow-up) */
+/* Code playground (Monaco-backed editor) */
 .playground-editor {
-  background: rgb(15 23 42);
-  color: rgb(226 232 240);
-  font-family: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
-  font-size: 0.82rem;
-  line-height: 1.65;
-  overflow-x: auto;
+  background: rgb(30 30 30); /* matches vs-dark theme */
+  height: 320px;
+  min-height: 320px;
+  overflow: hidden;
 }
-.playground-editor pre {
-  margin: 0;
-  padding: 12px 0;
-}
-.playground-editor code { display: block; }
-.playground-line {
-  display: flex;
-  align-items: baseline;
-  padding-right: 16px;
-}
-.playground-line:hover { background: rgba(255, 255, 255, 0.03); }
-.playground-line__num {
-  display: inline-block;
-  width: 44px;
-  flex-shrink: 0;
-  padding-right: 14px;
-  text-align: right;
-  color: rgb(100 116 139);
-  user-select: none;
-}
-.playground-line__src {
-  white-space: pre;
-  flex: 1;
-  min-width: 0;
+.playground-editor :deep(.monaco-editor) {
+  /* Let Monaco fill the container without inheriting any prose font-size. */
+  font-size: 13px;
 }
 .playground-output {
   margin: 0;
@@ -920,6 +964,13 @@ function loadTaskIntoPlayground(starter: string | null | undefined) {
   line-height: 1.6;
   color: rgb(55 65 81);
   white-space: pre-wrap;
+  word-break: break-word;
 }
 :global(.dark) .playground-output { color: rgb(203 213 225); }
+.playground-output--err {
+  color: rgb(220 38 38);
+}
+:global(.dark) .playground-output--err {
+  color: rgb(252 165 165);
+}
 </style>

--- a/frontend/app/components/StepConceptView.vue
+++ b/frontend/app/components/StepConceptView.vue
@@ -209,7 +209,7 @@
         </UCard>
 
         <!-- Code playground (read-only mock for now; execution comes in a follow-up PR) -->
-        <UCard v-if="step.has_playground && step.playground_starter_code" :ui="{ body: { padding: 'p-0' } }">
+        <UCard v-if="step.has_playground && step.playground_starter_code" ref="playgroundCard" :ui="{ body: { padding: 'p-0' } }">
           <template #header>
             <div class="flex items-center justify-between">
               <h2 class="flex items-center gap-2 text-base font-semibold text-gray-900 dark:text-white">
@@ -288,27 +288,44 @@
             <li
               v-for="(ins, i) in step.instructions"
               :key="ins.id"
-              class="group flex items-start gap-3 rounded-lg border border-gray-100 px-3 py-2.5 transition-colors hover:border-gray-200 dark:border-gray-700 dark:hover:border-gray-600"
+              class="group rounded-lg border border-gray-100 px-3 py-2.5 transition-colors hover:border-gray-200 dark:border-gray-700 dark:hover:border-gray-600"
               :class="checked.has(ins.id) && 'bg-emerald-50/60 dark:bg-emerald-950/20'"
             >
-              <button
-                type="button"
-                class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border-2 transition-colors"
-                :class="checked.has(ins.id)
-                  ? 'border-emerald-500 bg-emerald-500 text-white'
-                  : 'border-gray-300 dark:border-gray-600'"
-                @click="toggleCheck(ins.id)"
-              >
-                <UIcon v-if="checked.has(ins.id)" name="i-heroicons-check" class="h-3.5 w-3.5" />
-              </button>
-              <div class="min-w-0">
-                <p
-                  class="text-sm leading-relaxed text-gray-800 dark:text-gray-200"
-                  :class="checked.has(ins.id) && 'text-gray-400 line-through dark:text-gray-500'"
+              <div class="flex items-start gap-3">
+                <button
+                  type="button"
+                  class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md border-2 transition-colors"
+                  :class="checked.has(ins.id)
+                    ? 'border-emerald-500 bg-emerald-500 text-white'
+                    : 'border-gray-300 dark:border-gray-600'"
+                  @click="toggleCheck(ins.id)"
                 >
-                  <span class="mr-2 text-xs font-semibold text-gray-400">{{ String(i + 1).padStart(2, '0') }}.</span>
-                  {{ ins.text }}
-                </p>
+                  <UIcon v-if="checked.has(ins.id)" name="i-heroicons-check" class="h-3.5 w-3.5" />
+                </button>
+                <div class="min-w-0 flex-1">
+                  <p
+                    class="text-sm leading-relaxed text-gray-800 dark:text-gray-200"
+                    :class="checked.has(ins.id) && 'text-gray-400 line-through dark:text-gray-500'"
+                  >
+                    <span class="mr-2 text-xs font-semibold text-gray-400">{{ String(i + 1).padStart(2, '0') }}.</span>
+                    {{ ins.text }}
+                  </p>
+                  <!-- "Try this" button — only when the task ships with starter_code -->
+                  <div v-if="ins.starter_code" class="mt-2 flex items-center gap-2">
+                    <UButton
+                      size="xs"
+                      color="emerald"
+                      variant="soft"
+                      icon="i-heroicons-command-line"
+                      @click="loadTaskIntoPlayground(ins.starter_code)"
+                    >
+                      Try this in the playground
+                    </UButton>
+                    <span v-if="activeTaskId === ins.id" class="text-[10px] font-medium uppercase tracking-widest text-emerald-600 dark:text-emerald-400">
+                      Loaded ↑
+                    </span>
+                  </div>
+                </div>
               </div>
             </li>
           </ul>
@@ -623,12 +640,15 @@ onMounted(() => {
 const playgroundCode = ref(props.step.playground_starter_code ?? '')
 const playgroundOutput = ref('')
 const playgroundRunning = ref(false)
+const playgroundCard = ref<{ $el?: HTMLElement } | null>(null)
+const activeTaskId = ref<number | null>(null)
 const playgroundLines = computed(() => playgroundCode.value.split('\n').map(highlightPhp))
 const toast = useToast()
 
 function resetPlayground() {
   playgroundCode.value = props.step.playground_starter_code ?? ''
   playgroundOutput.value = ''
+  activeTaskId.value = null
 }
 
 async function runPlayground() {
@@ -642,6 +662,24 @@ async function runPlayground() {
     title: 'Playground execution coming soon',
     description: 'Wire-up to Judge0 lands in a follow-up PR.',
     color: 'amber',
+  })
+}
+
+// Load a task's starter into the playground and scroll the editor into
+// view. Always overwrites — users can click Reset on the playground to
+// go back to the step's primary starter.
+function loadTaskIntoPlayground(starter: string | null | undefined) {
+  if (!starter) return
+  const instructions = props.step.instructions ?? []
+  const task = instructions.find(t => t.starter_code === starter)
+  activeTaskId.value = task?.id ?? null
+  playgroundCode.value = starter
+  playgroundOutput.value = ''
+  nextTick(() => {
+    const el = playgroundCard.value?.$el ?? (playgroundCard.value as unknown as HTMLElement | null)
+    if (el && typeof (el as HTMLElement).scrollIntoView === 'function') {
+      (el as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
   })
 }
 </script>

--- a/frontend/app/composables/usePaths.ts
+++ b/frontend/app/composables/usePaths.ts
@@ -18,7 +18,7 @@ export interface PathStep {
   playground_starter_code?: string | null
   type: StepType
   lab_url?: string | null
-  instructions?: Array<{ id: number; text: string }>
+  instructions?: Array<{ id: number; text: string; starter_code?: string | null }>
   challenge_prompt?: string | null
   challenge_slug?: string | null
   challenge?: import('~/types/models').Challenge | null

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Api\PasswordResetController;
 use App\Http\Controllers\Api\PathController;
 use App\Http\Controllers\Api\PathStepController;
 use App\Http\Controllers\Api\PlanController;
+use App\Http\Controllers\Api\PlaygroundController;
 use App\Http\Controllers\Api\RoleController;
 use App\Http\Controllers\Api\SocialAuthController;
 use App\Http\Controllers\Api\StripeWebhookController;
@@ -70,6 +71,11 @@ Route::middleware(['auth:sanctum'])->group(function () {
     Route::get('/challenges', [ChallengeController::class, 'index']);
     Route::get('/challenges/{challenge:slug}', [ChallengeController::class, 'show']);
     Route::post('/challenges/{challenge:slug}/run', [ChallengeController::class, 'run']);
+
+    // Scratch playground — runs arbitrary PHP via Judge0 (no tests). Lightly
+    // throttled per-user to keep Judge0 calls bounded; the front-end shows
+    // the response as plain stdout/stderr.
+    Route::post('/playground/run', [PlaygroundController::class, 'run'])->middleware('throttle:30,1');
 
     // Step progress (all authenticated users update their own progress)
     Route::put('/path-steps/{step}/progress', [PathStepController::class, 'updateProgress']);


### PR DESCRIPTION
## Summary
Two concerns landed in the same PR because together they make practice actually possible:

1. **Per-task starter code** — each practice task can ship with `starter_code`; a *Try this in the playground* button appears under the task and loads the starter into the playground card.
2. **Real, editable playground** — the playground is now a Monaco editor (same one the ChallengeEditor uses, so no new bundle hit), and Run shells out to Judge0 via a new `/api/playground/run` endpoint.

## What's in
### Backend
- `PlaygroundExecutionService` mirrors `ChallengeExecutionService`'s Judge0 wiring but skips the PHPUnit bootstrap, namespace wrapper, and reflection-based test runner. User code is submitted verbatim and the response is shaped as `{ ok, stdout, stderr, exit_code, duration_ms, status }`. Compile errors and timeouts map to friendly status strings.
- `PlaygroundController::run()` validates `code` (≤10kB) and optional `language` (php-only for now). Route is rate-limited at **30 runs/min/user** to bound Judge0 spend.
- `PathStepController::stepRules()` accepts `instructions.*.starter_code` (`nullable|string|max:10000`).

### Frontend
- `StepConceptView.vue` swaps the read-only `<pre v-html>` for `<VueMonacoEditor>` wrapped in `<ClientOnly>` (SSR-safe). Reuses ChallengeEditor's font/ligature/word-wrap/tab options.
- `runPlayground()` POSTs to `/api/playground/run`; renders stdout in the output panel, stderr (timeout / compile / runtime) in red, plus a `{ms}` duration badge.
- Per-task **Try this in the playground** button; clicking loads the task's starter, scrolls the editor into view, and shows a *Loaded ↑* badge next to the originating task. Switching tasks overwrites the editor (scratch space — *Reset* on the playground card recovers the step's primary starter and clears the badge).
- A 429 from the throttle middleware shows an amber toast instead of dumping a generic error into the output panel.

### Seed (no migration — `instructions` is already JSON)
All five practice tasks on the *Modern PHP: Types, Nullables and Enums* step ship with runnable PHP starters:
1. `sanitizeSignup(array $raw): array` boilerplate with sample payloads
2. `calculateDiscount(...)` strict_types refactor target (uncomment guide)
3. The exploitable role-check `isAdmin()` with crafted-request examples
4. Empty `OrderStatus` enum + `match()` exhaustiveness skeleton
5. `sumCents` skeleton with expected outputs in trailing comments

## Out of scope / still queued
- **Per-user checklist persistence** — task checkboxes still live in component state.
- **Playground language ≠ PHP** — the validation is `in:php`, the Judge0 language ID is fixed. Multi-language support comes when we have a non-PHP step.
- **Editor session restore** — refreshing the page resets the editor to the step's primary starter; no localStorage persistence yet.

## Test plan
- [x] `ddev artisan test --compact` — 408 passed, 621 assertions.
- [x] `npx nuxi typecheck` — exit 0.
- [x] `ddev artisan route:list --path=playground` — POST `/api/playground/run` registered with `auth:sanctum` and `throttle:30,1`.
- [x] `ddev artisan tinker` — `PathStep::find(1)->instructions` returns 5 items, each with `starter_code` between ~478–756 bytes.
- [ ] Sign in, visit `/step/1`. Confirm:
  - Playground card has a real Monaco editor (cursor visible, syntax-highlighted PHP, you can type).
  - Click Run with the default starter → stdout shows the `OrderStatus::Paid` describe output, duration badge appears.
  - Edit the code to throw a parse error → output panel shows the compile error in red.
  - Add `sleep(10);` → output shows the "Time limit exceeded (5s)" message.
  - Scroll to Practice tasks → each has *Try this in the playground* button.
  - Click task 03 → editor loads the role-check vulnerability code, page scrolls to the playground, *Loaded ↑* badge appears next to task 03.
  - Click Reset on the playground → editor reverts to step starter, badge disappears.
  - Spam Run 31 times in a minute → 31st returns an amber "Slow down" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)